### PR TITLE
Refactor/measurement

### DIFF
--- a/importing/functions.py
+++ b/importing/functions.py
@@ -24,7 +24,7 @@ from django.db import connection, transaction
 from djangomain.settings import BASE_DIR
 from formatting.models import Association, Classification
 from importing.models import DataImportFull, DataImportTemp
-from measurement.models import WaterLevel, Var14Measurement
+from measurement.models import Var14Measurement, WaterLevel
 from variable.models import Variable
 
 unix_epoch = np.datetime64(0, "s")

--- a/measurement/models.py
+++ b/measurement/models.py
@@ -12,13 +12,12 @@
 ########################################################################################
 from __future__ import unicode_literals
 
-from typing import Type, List
+from typing import List, Type
 
 from django.db import models
 from django.urls import reverse
 
 from station.models import Station
-
 
 MEASUREMENTS: List[str] = []
 """Available measurent variables."""

--- a/scripts/unused_scripts/llenar_datos_ale.py
+++ b/scripts/unused_scripts/llenar_datos_ale.py
@@ -14,7 +14,7 @@ from datetime import date, datetime, time, timedelta
 
 from django.db import connection
 
-from measurement.models import WindVelocity, WindDirection
+from measurement.models import WindDirection, WindVelocity
 
 
 def llenarPrecipitacion():


### PR DESCRIPTION
Makes a few changes in `measurement/model.py` to have explicit variable names. The variable classes are registered in a `MEASUREMENTS` global variable that can be used to loop over the measurements when required.

Multiple inheritance has also been removed by making the dynamic, abstract class to inherit from `BaseMeasurement` directly. I also suspect this function can be removed altogether and use the `__init_subclass__` classmethod of `BaseMeasurement` to initialise the fields of the child classes, but that's a further refinement to be done in the future. 

Close #47