### PR TITLE
Adds the new report model

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip wheel
         pip install -r requirements.txt
+        pip install -r requirements-dev.txt
     - name: Run migrations
       run: python manage.py migrate
     - name: Run tests

--- a/measurement/models.py
+++ b/measurement/models.py
@@ -19,9 +19,54 @@ from django.urls import reverse
 from timescale.db.models.models import TimescaleModel
 
 from station.models import Station
+from variable.models import Variable
 
 MEASUREMENTS: List[str] = []
 """Available measurement variables."""
+
+
+class MeasurementBase(TimescaleModel):
+    """Base class for all the measurement related entries.
+
+    It contains the barebone attributes that any measurement entry will likely need,
+    although this is enforced only for station, variable and value. Maximum and minimum
+    are very likely to be present in most cases, but might not be there in some
+    occasions, therefore the possibility of nulling them.
+    """
+
+    station = models.ForeignKey(
+        Station, on_delete=models.PROTECT, null=False, verbose_name="Station"
+    )
+    variable = models.ForeignKey(
+        Variable, on_delete=models.PROTECT, null=False, verbose_name="Variable"
+    )
+    value = models.DecimalField(
+        "value",
+        max_digits=14,
+        decimal_places=6,
+        null=False,
+    )
+    maximum = models.DecimalField(
+        "maximum",
+        max_digits=14,
+        decimal_places=6,
+        null=True,
+    )
+    minimum = models.DecimalField(
+        "minimum",
+        max_digits=14,
+        decimal_places=6,
+        null=True,
+    )
+
+    class Meta:
+        default_permissions = ()
+        abstract = True
+        indexes = [
+            models.Index(fields=["station", "variable", "time"]),
+            models.Index(fields=["variable", "station", "time"]),
+            models.Index(fields=["time", "station", "variable"]),
+        ]
 
 
 class PermissionsMeasurement(models.Model):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@ black
 isort
 flake8
 pre-commit
+model_bakery

--- a/tests/measurement/test_models.py
+++ b/tests/measurement/test_models.py
@@ -2,6 +2,7 @@ from datetime import datetime
 
 import pytz
 from django.test import TestCase
+from model_bakery import baker
 
 
 class TestModelCreation(TestCase):
@@ -46,8 +47,9 @@ class TestModelCreation(TestCase):
     def test_timescale_query(self):
         from measurement.models import Flow
 
-        start_time, end_time = datetime(2015, 1, 1, tzinfo=pytz.UTC), datetime(
-            2016, 11, 10, tzinfo=pytz.UTC
+        start_time, end_time = (
+            datetime(2015, 1, 1, tzinfo=pytz.UTC),
+            datetime(2016, 11, 10, tzinfo=pytz.UTC),
         )
         query = Flow.timescale.filter(time__range=[start_time, end_time], station_id=1)
         self.assertEqual(len(query), 2)
@@ -65,3 +67,53 @@ class TestModelCreation(TestCase):
         query = Precipitation.timescale.filter(station_id=2).order_by("-time")
         self.assertEqual(query[0].time.year, 2018)
         self.assertEqual(query[1].time.year, 2017)
+
+
+class TestReport(TestCase):
+    def setUp(self) -> None:
+        from measurement.models import Report, ReportType
+        from station.models import Station
+        from variable.models import Variable
+
+        station = baker.make(Station)
+        variable = baker.make(Variable)
+        self.model: Report = Report(
+            time=datetime(2018, 1, 9, 23, 55, 59, tzinfo=pytz.UTC),
+            station=station,
+            variable=variable,
+            value=42,
+            report_type=ReportType.HOURLY,
+        )
+
+    def test_clean(self):
+        from measurement.models import ReportType
+
+        # We check 'used_for_daily' compatibility
+        # Works if report type is Hourly
+        self.model.used_for_daily = True
+        self.model.clean()
+
+        # But fails for the other two
+        self.model.report_type = ReportType.DAILY
+        with self.assertRaises(ValueError):
+            self.model.clean()
+
+        self.model.report_type = ReportType.MONTLY
+        with self.assertRaises(ValueError):
+            self.model.clean()
+
+        # We check 'used_for_monthly' compatibility
+        # Works if report type is Daily
+        self.model.used_for_daily = False
+        self.model.used_for_monthly = True
+        self.model.report_type = ReportType.DAILY
+        self.model.clean()
+
+        # But not for the other two
+        self.model.report_type = ReportType.HOURLY
+        with self.assertRaises(ValueError):
+            self.model.clean()
+
+        self.model.report_type = ReportType.MONTLY
+        with self.assertRaises(ValueError):
+            self.model.clean()


### PR DESCRIPTION
Close #115 

Ads the new Report model, inheriting from `MeasurementBase` (see #128 ), including the report type, flags to indicate when it has been used and validation. 

For the tests, the package `model_bakery` has been added, and the CI the workflow file has been updated accordingly. I've also added this to the Dockerfile as we are in the development phase. Ideally, we will want to get rid of it in production, so the image do not include unnecessary packages, but it should be ok for now. 