### PR TITLE
Add synthetic data creation scenarios

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,120 +7,121 @@ db.sqlite3
 media
 */db/*
 
-# Migrations 
+# Migrations
 # We don't want to ignore migrations because we have data migrations to set up groups
 # and permissions.
 
-# Backup files # 
-*.bak 
+# Backup files #
+*.bak
 
-# If you are using PyCharm # 
+# If you are using PyCharm #
 .idea
-.idea/**/workspace.xml 
-.idea/**/tasks.xml 
-.idea/dictionaries 
-.idea/**/dataSources/ 
-.idea/**/dataSources.ids 
-.idea/**/dataSources.xml 
-.idea/**/dataSources.local.xml 
-.idea/**/sqlDataSources.xml 
-.idea/**/dynamic.xml 
-.idea/**/uiDesigner.xml 
-.idea/**/gradle.xml 
-.idea/**/libraries 
-*.iws /out/ 
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/dictionaries
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.xml
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/gradle.xml
+.idea/**/libraries
+*.iws /out/
 
-# Python # 
-*.py[cod] 
-*$py.class 
+# Python #
+*.py[cod]
+*$py.class
 
-# Distribution / packaging 
-.Python build/ 
-develop-eggs/ 
-dist/ 
-downloads/ 
-eggs/ 
-.eggs/ 
-lib/ 
-lib64/ 
-parts/ 
-sdist/ 
-var/ 
-wheels/ 
-*.egg-info/ 
-.installed.cfg 
-*.egg 
-*.manifest 
-*.spec 
+# Distribution / packaging
+.Python build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+*.manifest
+*.spec
 
-# Installer logs 
-pip-log.txt 
-pip-delete-this-directory.txt 
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
 
-# Unit test / coverage reports 
-htmlcov/ 
-.tox/ 
-.coverage 
-.coverage.* 
-.cache 
-.pytest_cache/ 
-nosetests.xml 
-coverage.xml 
-*.cover 
-.hypothesis/ 
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+.pytest_cache/
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
 
-# Jupyter Notebook 
-.ipynb_checkpoints 
+# Jupyter Notebook
+.ipynb_checkpoints
 
-# pyenv 
-.python-version 
+# pyenv
+.python-version
 
-# celery 
-celerybeat-schedule.* 
+# celery
+celerybeat-schedule.*
 
-# SageMath parsed files 
-*.sage.py 
+# SageMath parsed files
+*.sage.py
 
-# Environments 
-.env 
-.venv 
-env/ 
-venv/ 
-ENV/ 
-env.bak/ 
-venv.bak/ 
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
 
-# mkdocs documentation 
-/site 
+# mkdocs documentation
+/site
 
-# mypy 
-.mypy_cache/ 
+# mypy
+.mypy_cache/
 
-# Sublime Text # 
-*.tmlanguage.cache 
-*.tmPreferences.cache 
-*.stTheme.cache 
-*.sublime-workspace 
-*.sublime-project 
+# Sublime Text #
+*.tmlanguage.cache
+*.tmPreferences.cache
+*.stTheme.cache
+*.sublime-workspace
+*.sublime-project
 
-# sftp configuration file 
-sftp-config.json 
+# sftp configuration file
+sftp-config.json
 
-# Package control specific files Package 
-Control.last-run 
-Control.ca-list 
-Control.ca-bundle 
-Control.system-ca-bundle 
-GitHub.sublime-settings 
+# Package control specific files Package
+Control.last-run
+Control.ca-list
+Control.ca-bundle
+Control.system-ca-bundle
+GitHub.sublime-settings
 
-# Visual Studio Code # 
-.vscode/* 
-.vscode/settings.json 
-!.vscode/tasks.json 
-!.vscode/launch.json 
-!.vscode/extensions.json 
+# Visual Studio Code #
+.vscode/*
+.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
 .history
 
 # Other excluded
 _other/
 log/
+scratch/

--- a/README.md
+++ b/README.md
@@ -93,6 +93,16 @@ For that to work, development-related dependencies needs to be installed. To do 
 python -m pip install -r requirements-dev.txt
 ```
 
+### Synthetic data
+
+Synthetic data can be added to the database for benchmarking purposes using one of the scenarios in `utilities/benchmarking` or creating one of your own. To do so:
+
+- Populate the database with some initial data for the `Station`, `Variable` and all the required models (see the *Getting Started* section).
+- Install the development dependencies (read the *Tests* section)
+- Run your desired synthetic data scenario.
+
+If you run one of the built in ones, you should see a progressbar for the process and, if you log in into the Django Admin of Paricia (`http://localhost:8000/admin`), then you will see the records for the `Measurements` model increasing.
+
 ### Continuous integration
 
 Pre-commit hooks are set up to run code quality checks (isort and black) before committing. To run these locally, you will need to `pip install pre-commit` then `pre-commit install`. Now, quality assurance tools will be run automatically with every commit.

--- a/README.md
+++ b/README.md
@@ -87,8 +87,14 @@ The code was originally based on the iMHEA platform - Plataforma para la **I**ni
 
 The tests are run with `python manage.py test` from inside the docker container.
 
+For that to work, development-related dependencies needs to be installed. To do that, get into the container (see instructions at the top) and run:
+
+```bash
+python -m pip install -r requirements-dev.txt
+```
+
 ### Continuous integration
 
-Pre-commit hooks are set up to run code quality checks (isort and black) before committing. To run these locally, you will need to `pip install pre-commit` then `pre-commit install`.
+Pre-commit hooks are set up to run code quality checks (isort and black) before committing. To run these locally, you will need to `pip install pre-commit` then `pre-commit install`. Now, quality assurance tools will be run automatically with every commit.
+
 Github workflows are set up to run the pre-commit actions and the tests automatically on every push action.
-Run before commit: `pre-commit run --all-files`

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,4 @@ isort
 flake8
 pre-commit
 model_bakery
+tqdm

--- a/utilities/benchmarking/create_synthetic_data_scenario1.py
+++ b/utilities/benchmarking/create_synthetic_data_scenario1.py
@@ -1,0 +1,68 @@
+import itertools
+import os
+import random
+import sys
+import time
+import zoneinfo
+from datetime import datetime
+from decimal import Decimal
+
+import django
+import pandas as pd
+from tqdm import tqdm
+
+# This needs to be done before importing any model
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", ".."))
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "djangomain.settings")
+django.setup()
+
+from measurement.models import Measurement  # noqa: E402
+
+# Now we can import the models
+from station.models import Station  # noqa: E402
+from variable.models import Variable  # noqa: E402
+
+variables = list(Variable.objects.all())[:10]
+years = list(range(2000, 2023))
+
+station = Station.objects.first()
+station.timezone = "UTC"
+station.save()
+tz = zoneinfo.ZoneInfo(station.timezone)
+
+progress = tqdm(
+    itertools.product(years, variables),
+    total=len(years) * len(variables),
+    desc="Creating synthetic data",
+)
+nrecords = 0
+execution = []
+for year, variable in progress:
+    start = datetime(year, 1, 1, tzinfo=tz)
+    end = datetime(year + 1, 1, 1, tzinfo=tz)
+    minimum: int = random.randint(-5, 5)
+    maximum: int = random.randint(20, 30)
+
+    tstart = time.time()
+    records = [
+        Measurement(
+            station=station,
+            variable=variable,
+            time=t,
+            value=Decimal(random.randint(minimum, maximum)),
+            minimum=Decimal(minimum),
+            maximum=Decimal(maximum),
+        )
+        for t in pd.date_range(start, end, freq="5min", inclusive="left")
+    ]
+
+    [r.clean() for r in records]  # type: ignore
+    Measurement.objects.bulk_create(records)
+    tend = time.time()
+    nrecords += len(records)
+    execution.append((nrecords, tend - tstart))
+
+os.makedirs("scratch", exist_ok=True)
+pd.DataFrame(execution, columns=["nrecords", "time"]).to_csv(
+    "scratch/execution_scenario1.csv"
+)

--- a/utilities/benchmarking/create_synthetic_data_scenario1.py
+++ b/utilities/benchmarking/create_synthetic_data_scenario1.py
@@ -35,7 +35,8 @@ variables = list(Variable.objects.all())[:10]
 years = list(range(2000, 2023))
 
 station = Station.objects.first()
-station.timezone = "UTC"
+if station.timezone is None:
+    station.timezone = "UTC"
 station.save()
 tz = zoneinfo.ZoneInfo(station.timezone)
 

--- a/utilities/benchmarking/create_synthetic_data_scenario1.py
+++ b/utilities/benchmarking/create_synthetic_data_scenario1.py
@@ -1,3 +1,12 @@
+"""Scenario for creating synthetic data for benchmarking purposes.
+
+This scenario creates synthetic data for a single station and a set of variables for a
+range of years. It results in a database structure where the number of records is
+spread evenly across the years and variables. As the default chunk time interval for
+the TimescaleDB is 1 day, this scenario results in many chunks (>8000) with just a few
+records each (~3000).
+"""
+
 import itertools
 import os
 import random

--- a/utilities/benchmarking/create_synthetic_data_scenario2.py
+++ b/utilities/benchmarking/create_synthetic_data_scenario2.py
@@ -1,3 +1,14 @@
+"""Scenario for creating synthetic data for benchmarking purposes.
+
+This scenario creates synthetic data for a set of stations and variables for a single
+year. It results in a database structure where the number of records is
+spread evenly across the years and variables. As the default chunk time interval for
+the TimescaleDB is 1 day, this scenario results in not that many chunks (365) and a
+higher number of records per chunk that the previous scenario (~66000), althoguh the
+total number of records is the same. Even per chunk, the number of records is still
+pretty small, sugesting that the performance will not be that different.
+"""
+
 import itertools
 import os
 import random

--- a/utilities/benchmarking/create_synthetic_data_scenario2.py
+++ b/utilities/benchmarking/create_synthetic_data_scenario2.py
@@ -4,7 +4,7 @@ This scenario creates synthetic data for a set of stations and variables for a s
 year. It results in a database structure where the number of records is
 spread evenly across the years and variables. As the default chunk time interval for
 the TimescaleDB is 1 day, this scenario results in not that many chunks (365) and a
-higher number of records per chunk that the previous scenario (~66000), althoguh the
+higher number of records per chunk that the previous scenario (~66000), although the
 total number of records is the same. Even per chunk, the number of records is still
 pretty small, sugesting that the performance will not be that different.
 """

--- a/utilities/benchmarking/create_synthetic_data_scenario2.py
+++ b/utilities/benchmarking/create_synthetic_data_scenario2.py
@@ -1,0 +1,70 @@
+import itertools
+import os
+import random
+import sys
+import time
+import zoneinfo
+from datetime import datetime
+from decimal import Decimal
+
+import django
+import pandas as pd
+from tqdm import tqdm
+
+# This needs to be done before importing any model
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", ".."))
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "djangomain.settings")
+django.setup()
+
+from measurement.models import Measurement  # noqa: E402
+
+# Now we can import the models
+from station.models import Station  # noqa: E402
+from variable.models import Variable  # noqa: E402
+
+variables = list(Variable.objects.all())[:10]
+
+stations = list(Station.objects.all())[:23]
+for s in stations:
+    s.timezone = "UTC"
+    s.save()
+tz = zoneinfo.ZoneInfo(stations[0].timezone)
+
+start = datetime(2023, 1, 1, tzinfo=tz)
+end = datetime(2024, 1, 1, tzinfo=tz)
+date_range = pd.date_range(start, end, freq="5min", inclusive="left")
+
+progress = tqdm(
+    itertools.product(stations, variables),
+    total=len(stations) * len(variables),
+    desc="Creating synthetic data",
+)
+nrecords = 0
+execution = []
+for station, variable in progress:
+    minimum: int = random.randint(-5, 5)
+    maximum: int = random.randint(20, 30)
+
+    tstart = time.time()
+    records = [
+        Measurement(
+            station=station,
+            variable=variable,
+            time=t,
+            value=Decimal(random.randint(minimum, maximum)),
+            minimum=Decimal(minimum),
+            maximum=Decimal(maximum),
+        )
+        for t in date_range
+    ]
+
+    [r.clean() for r in records]  # type: ignore
+    Measurement.objects.bulk_create(records)
+    tend = time.time()
+    nrecords += len(records)
+    execution.append((nrecords, tend - tstart))
+
+os.makedirs("scratch", exist_ok=True)
+pd.DataFrame(execution, columns=["nrecords", "time"]).to_csv(
+    "scratch/execution_scenario2.csv"
+)

--- a/utilities/benchmarking/create_synthetic_data_scenario2.py
+++ b/utilities/benchmarking/create_synthetic_data_scenario2.py
@@ -37,6 +37,8 @@ variables = list(Variable.objects.all())[:10]
 
 stations = list(Station.objects.all())[:23]
 for s in stations:
+    if s.timezone is not None:
+        continue
     s.timezone = "UTC"
     s.save()
 tz = zoneinfo.ZoneInfo(stations[0].timezone)


### PR DESCRIPTION
Adds the scripts to create synthetic data in two scenarios, ~ 24M entries spread over 23 years and the same entries compressed in just 1 year. 

A Wiki summarising the findings is included here: https://github.com/ImperialCollegeLondon/paricia/wiki/Performance-benchmarking