### PR TITLE
Data Report dash app

### DIFF
--- a/validated/dash_apps/finished_apps/data_report.py
+++ b/validated/dash_apps/finished_apps/data_report.py
@@ -1,0 +1,122 @@
+from datetime import datetime
+from decimal import Decimal
+
+import plotly.express as px
+from dash import dcc, html, Input, Output
+from django_plotly_dash import DjangoDash
+
+import pandas as pd
+
+from station.models import Station
+from validated.functions import dict_data_report
+from variable.models import Variable
+
+# Create a Dash app
+app = DjangoDash("DataReport")
+
+
+# Initial values
+station: Station = Station.objects.order_by("station_code")[7]
+variable: Variable = Variable.objects.order_by("variable_code")[0]
+start_time: str = datetime.strptime("2023-03-01", "%Y-%m-%d")
+end_time: str = datetime.strptime("2023-03-31", "%Y-%m-%d")
+temporality: str = "measurement"
+
+
+def plot_graph(
+    temporality: str,
+    station: Station,
+    variable: Variable,
+    start_time: str,
+    end_time: str,
+):
+    # Load data
+    data: dict = dict_data_report(
+        temporality=temporality,
+        station=station,
+        variable=variable,
+        start_time=start_time,
+        end_time=end_time,
+    )
+
+    # Create plot
+    x = data["series"]["time"]
+    y = data["series"]["average"]
+    plot = px.line(x=x, y=y)
+
+    return plot
+
+
+plot = plot_graph(
+    temporality,
+    station,
+    variable,
+    start_time,
+    end_time,
+)
+
+
+# Create layout
+app.layout = html.Div([
+    dcc.Dropdown(
+        id="temporality_drop",
+        options=[
+            {'label': 'Raw measurement', 'value': 'measurement'},
+            {'label': 'Validated measurement', 'value': 'validated'},
+            {'label': 'Hourly', 'value': 'hourly'},
+            {'label': 'Daily', 'value': 'daily'},
+            {'label': 'Monthly', 'value': 'monthly'},
+        ],
+        value="measurement",
+    ),
+    dcc.Dropdown(
+        id="station_drop",
+        #options=Station.objects.order_by("station_code"),
+        options=[item.station_code for item in Station.objects.order_by("station_code")],
+        value=station.station_code,
+    ),
+    dcc.Dropdown(
+        id="variable_drop",
+        options=[{'label': item.name, 'value': item.variable_code} for item in Variable.objects.order_by("variable_code")],
+        value=variable.variable_code,
+    ),
+    dcc.DatePickerRange(
+        id="date_range_picker",
+        display_format="YYYY-MM-DD",
+        start_date="2023-03-01",
+        end_date="2023-03-31",
+    ),
+    dcc.Graph(id="data_report_graph", figure=plot)
+])
+
+
+@app.callback(
+    Output("data_report_graph", "figure"),
+    [
+        Input("temporality_drop", "value"),
+        Input("station_drop", "value"),
+        Input("variable_drop", "value"),
+        Input("date_range_picker", "start_date"),
+        Input("date_range_picker", "end_date"),
+    ],
+)
+def update_button_click(
+    temporality: str,
+    station: str,
+    variable: str,
+    start_time: str,
+    end_time: str,
+) -> px.line:
+
+    station = Station.objects.get(station_code=station)
+    variable = Variable.objects.get(variable_code=variable)
+    
+    plot = plot_graph(
+        temporality,
+        station,
+        variable,
+        start_time,
+        end_time,
+    )
+
+    return plot

--- a/validated/templates/data_report_dev.html
+++ b/validated/templates/data_report_dev.html
@@ -1,0 +1,5 @@
+{% load plotly_dash %}
+
+<div class="{% plotly_class name='DataReport' %} card" style="height: 100%; width: 100%">
+{% plotly_app name="DataReport" ratio=1 %}
+</div>

--- a/validated/urls.py
+++ b/validated/urls.py
@@ -72,6 +72,11 @@ urlpatterns = [
         views.DailyValidationDev.as_view(),
         name="daily_validation_dev",
     ),
+    path(
+        "data_report_dev/",
+        views.DataReportDev.as_view(),
+        name="data_report_dev",
+    ),
 ]
 
 urlpatterns = format_suffix_patterns(urlpatterns)

--- a/validated/views.py
+++ b/validated/views.py
@@ -432,6 +432,13 @@ class DailyValidationDev(View):
         from .dash_apps.finished_apps import daily_validation
 
         return render(request, "daily_validation_dev.html")
+    
+
+class DataReportDev(View):
+    def get(self, request, *args, **kwargs):
+        from .dash_apps.finished_apps import data_report
+
+        return render(request, "data_report_dev.html")
 
 
 def view_launch_report_calculations(request):


### PR DESCRIPTION
Created a new dash app that can be accessed at http://localhost:8000/validated/data_report_dev/. This replicates the functionality of the original `data_report` page entirely within the dash app. The app layout and callback function is currently in a state where changing values in the dropdowns/date picker will immediately update the graph.

Still to be done:
- There is no error handling at the moment so if the parameters are set in a way that provides no data, the graph doesn't update
- General layout, headings etc. need to be changed
- Need to add the minimum/maximum plots