### PR TITLE
Daily validation dash app

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ PyYAML==6.0.1
 uritemplate==4.1.1
 crispy-bootstrap4==2023.1
 django-plotly-dash==2.2.2
+dash-ag-grid==2.4.0
 
 ## Legacy dependency versions
 # asgiref==3.3.4

--- a/static/styles/dashstyle.css
+++ b/static/styles/dashstyle.css
@@ -1,0 +1,15 @@
+body {
+    font-family: Open Sans, Raleway, Dosis, Ubuntu, sans-serif;
+}
+
+.DateInput_input, .DateInput_input_1 {
+    font-size: inherit;
+    Height: 30px;
+}
+
+.Select-input{
+    height: 30px;
+}
+.Select-control{
+    height: 30px;
+}

--- a/validated/dash_apps/finished_apps/daily_validation.py
+++ b/validated/dash_apps/finished_apps/daily_validation.py
@@ -21,9 +21,9 @@ from validated.plots import create_validation_plot
 from validated.tables import create_columns_daily, create_columns_detail
 from variable.models import Variable
 
-DEFAULT_FONT = "Open Sans, Raleway, Dosis, Ubuntu, sans-serif"
-
-app = DjangoDash("DailyValidation")
+app = DjangoDash(
+    "DailyValidation", external_stylesheets=["/static/styles/dashstyle.css"]
+)
 
 # Initial filters
 STATION: Station = Station.objects.order_by("station_code")[7]
@@ -115,7 +115,6 @@ filters = html.Div(
     style={
         "display": "flex",
         "justify-content": "flex-start",
-        "font-family": DEFAULT_FONT,
         "font-size": "14px",
     },
 )
@@ -192,7 +191,6 @@ detail_date_picker = html.Div(
         "display": "inline-block",
         "width": "50%",
         "text-align": "right",
-        "font-family": DEFAULT_FONT,
     },
 )
 
@@ -225,7 +223,6 @@ status_message = html.Div(
     id="status-message",
     children=[""],
     style={
-        "font-family": DEFAULT_FONT,
         "font-size": "14px",
         "min-height": "20px",
         "padding-top": "5px",
@@ -245,14 +242,14 @@ plot_radio = dcc.RadioItems(
     ],
     value=PLOT_TYPE,
     inline=True,
-    style={"font-family": DEFAULT_FONT, "font-size": "14px"},
+    style={"font-size": "14px"},
 )
 
 # Layout
 app.layout = html.Div(
     children=[
         filters,
-        html.Button("Submit", id="submit-button"),
+        html.Button("Submit", id="submit-button", style={"margin-top": "10px"}),
         dcc.Loading(
             type="dot",
             children=html.Div(id="loading_top"),
@@ -267,8 +264,6 @@ app.layout = html.Div(
                     label="Daily Report",
                     id="tab-daily",
                     value="tab-daily",
-                    style={"font-family": DEFAULT_FONT},
-                    selected_style={"font-family": DEFAULT_FONT},
                     children=[
                         table_daily,
                     ],
@@ -278,9 +273,6 @@ app.layout = html.Div(
                     id="tab-detail",
                     value="tab-detail",
                     disabled=True,
-                    style={"font-family": DEFAULT_FONT},
-                    selected_style={"font-family": DEFAULT_FONT},
-                    disabled_style={"font-family": DEFAULT_FONT},
                     children=[
                         table_detail,
                     ],

--- a/validated/dash_apps/finished_apps/daily_validation.py
+++ b/validated/dash_apps/finished_apps/daily_validation.py
@@ -374,23 +374,29 @@ def callbacks(
     str,
     bool,
 ]:
-    """Callback for buttons adding and resetting Validated data
+    """Callbacks for daily validation app
 
     Args:
-        daily_save_clicks (int): Number of times daily-save-button was clicked
-        daily_reset_clicks (int): Number of times daily-reset-button was clicked
-        detail_save_clicks (int): Number of times detail-save-button was clicked
-        detail_reset_clicks (int): Number of times detail-reset-button was clicked
-        detail_add_clicks (int): Number of times detail-add-button was clicked
-        daily_id (int): ID of selected day
-        plot_radio_value (str): Value of plot radio button
+        in_submit_clicks (int): Number of times submit-button was clicked
+        in_save_clicks (int): Number of times save-button was clicked
+        in_reset_clicks (int): Number of times reset-button was clicked
+        in_add_clicks (int): Number of times add-button was clicked
+        in_detail_date (datetime.date): Date for detail view
+        in_plot_radio_value (str): Value of plot radio button
+        in_tabs_value (str): Value of tabs
+        in_station (str): Station from filters
+        in_variable (str): Variable from filters
+        in_start_date (str): Start date from filters
+        in_end_date (str): End date from filters
+        in_minimum (float): Minimum from filters
+        in_maximum (float): Maximum from filters
         in_daily_selected_rows (list[dict]): Selected rows in table_daily
+        in_daily_row_data (list[dict]): Full row data for table_daily
         in_detail_selected_rows (list[dict]): Selected rows in table_detail
         in_detail_row_data (list[dict]): Full row data for table_detail
 
     Returns:
-        tuple[str, str, go.Figure, list[dict], list[dict], dict, dict, list[dict], list[dict], bool, str, str]:
-            Callback outputs
+        tuple[ dash.no_update, dash.no_update, str, go.Figure, list[dict], list[dict], dict, dict, list[dict], list[dict], bool, str, str, bool, ]: Outputs
     """
     global DATA_DAILY, DATA_DETAIL, STATION, VARIABLE, START_DATE, END_DATE, MINIMUM, MAXIMUM, SELECTED_DAY, PLOT_TYPE
 
@@ -426,8 +432,9 @@ def callbacks(
         VARIABLE = Variable.objects.get(variable_code=in_variable)
         START_DATE = datetime.strptime(in_start_date, "%Y-%m-%d")
         END_DATE = datetime.strptime(in_end_date, "%Y-%m-%d")
-        MINIMUM = Decimal(in_minimum)
-        MAXIMUM = Decimal(in_maximum)
+        MINIMUM = Decimal(in_minimum) if in_minimum is not None else None
+        MAXIMUM = Decimal(in_maximum) if in_maximum is not None else None
+        out_status = ""
         daily_data_refresh_required = True
         detail_data_refresh_required = True
         daily_table_refresh_required = True

--- a/validated/dash_apps/finished_apps/daily_validation.py
+++ b/validated/dash_apps/finished_apps/daily_validation.py
@@ -1,13 +1,23 @@
 from datetime import datetime
 from decimal import Decimal
 
+import dash
 import plotly.graph_objects as go
-from dash import dcc, html
+from dash import Input, Output, State, dcc, html
+from dash_ag_grid import AgGrid
 from django_plotly_dash import DjangoDash
 
 from station.models import Station
-from validated.functions import daily_validation, detail_list
-from validated.tables import create_daily_table, create_detail_table
+from validated.functions import (
+    daily_validation,
+    detail_list,
+    get_conditions,
+    reset_daily_validated,
+    reset_detail_validated,
+    save_detail_to_validated,
+    save_to_validated,
+)
+from validated.tables import create_columns_daily, create_columns_detail
 from variable.models import Variable
 
 DEFAULT_FONT = "Open Sans, Raleway, Dosis, Ubuntu, sans-serif"
@@ -15,66 +25,117 @@ DEFAULT_FONT = "Open Sans, Raleway, Dosis, Ubuntu, sans-serif"
 app = DjangoDash("DailyValidation")
 
 # Filters (in final app this will get data from forms)
-station: Station = Station.objects.order_by("station_code")[7]
-variable: Variable = Variable.objects.order_by("variable_code")[0]
-start_time: datetime = datetime.strptime("2023-03-01", "%Y-%m-%d")
-end_time: datetime = datetime.strptime("2023-03-31", "%Y-%m-%d")
-minimum: Decimal = Decimal(-5)
-maximum: Decimal = Decimal(28)
+STATION: Station = Station.objects.order_by("station_code")[7]
+VARIABLE: Variable = Variable.objects.order_by("variable_code")[0]
+START_DATE: datetime = datetime.strptime("2023-03-01", "%Y-%m-%d")
+END_DATE: datetime = datetime.strptime("2023-03-31", "%Y-%m-%d")
+MINIMUM: Decimal = Decimal(-5)
+MAXIMUM: Decimal = Decimal(28)
+SELECTED_DAY: datetime = datetime.strptime("2023-03-14", "%Y-%m-%d")
 
 # Daily data
-data: dict = daily_validation(
-    station=station,
-    variable=variable,
-    start_time=start_time,
-    end_time=end_time,
-    minimum=minimum,
-    maximum=maximum,
+DATA_DAILY = daily_validation(
+    station=STATION,
+    variable=VARIABLE,
+    start_time=START_DATE,
+    end_time=END_DATE,
+    minimum=MINIMUM,
+    maximum=MAXIMUM,
 )
 
 # Detail data
-date: datetime = datetime.strptime("2023-03-14", "%Y-%m-%d")
-data_detail = detail_list(
-    station=station,
-    variable=variable,
-    date_of_interest=date,
-    minimum=minimum,
-    maximum=maximum,
+DATA_DETAIL = detail_list(
+    station=STATION,
+    variable=VARIABLE,
+    date_of_interest=SELECTED_DAY,
+    minimum=MINIMUM,
+    maximum=MAXIMUM,
 )
 
 # Tables
-table_daily = create_daily_table(data)
-table_detail = create_detail_table(data_detail)
+table_daily = AgGrid(
+    id="table_daily",
+    rowData=DATA_DAILY["data"],
+    columnDefs=create_columns_daily(value_columns=DATA_DAILY["value_columns"]),
+    columnSize="sizeToFit",
+    defaultColDef={
+        "resizable": True,
+        "sortable": True,
+        "checkboxSelection": {
+            "function": "params.column == params.columnApi.getAllDisplayedColumns()[0]"
+        },
+        "headerCheckboxSelection": {
+            "function": "params.column == params.columnApi.getAllDisplayedColumns()[0]"
+        },
+        "headerCheckboxSelectionFilteredOnly": True,
+    },
+    dashGridOptions={
+        "rowSelection": "multiple",
+        "suppressRowClickSelection": True,
+    },
+    selectAll=True,
+    getRowId="params.data.id",
+)
+
+table_detail = AgGrid(
+    id="table_detail",
+    rowData=DATA_DETAIL["series"],
+    columnDefs=create_columns_detail(value_columns=DATA_DETAIL["value_columns"]),
+    columnSize="sizeToFit",
+    defaultColDef={
+        "resizable": True,
+        "sortable": True,
+        "checkboxSelection": {
+            "function": "params.column == params.columnApi.getAllDisplayedColumns()[0]"
+        },
+        "headerCheckboxSelection": {
+            "function": "params.column == params.columnApi.getAllDisplayedColumns()[0]"
+        },
+        "headerCheckboxSelectionFilteredOnly": True,
+    },
+    dashGridOptions={
+        "rowSelection": "multiple",
+        "suppressRowClickSelection": True,
+    },
+    selectAll=True,
+    getRowId="params.data.id",
+)
+
 
 # Plot
-plot = go.Figure()
-plot.add_trace(
-    go.Scatter(
-        x=data["series"]["measurement"]["time"],
-        y=data["series"]["measurement"]["average"],
-        mode="lines",
-        name="Measurement",
-        line=dict(color="black"),
-    )
-)
-plot.add_trace(
-    go.Scatter(
-        x=data["series"]["selected"]["time"],
-        y=data["series"]["selected"]["average"],
-        mode="lines",
-        name="Selected",
-        line=dict(color="#636EFA"),
-    )
-)
-plot.add_trace(
-    go.Scatter(
-        x=data["series"]["validated"]["time"],
-        y=data["series"]["validated"]["average"],
-        mode="lines",
-        name="Validated",
-        line=dict(color="#00CC96"),
-    )
-)
+def create_validation_plot(data: dict) -> go.Figure:
+    """Creates plot for Validation app
+
+    Args:
+        data (dict): Daily data series
+
+    Returns:
+        go.Figure: Plot
+    """
+    plot = go.Figure()
+
+    datasets = [
+        {"key": "measurement", "name": "Measurement", "color": "black"},
+        {"key": "selected", "name": "Selected", "color": "#636EFA"},
+        {"key": "validated", "name": "Validated", "color": "#00CC96"},
+    ]
+
+    for dataset in datasets:
+        plot.add_trace(
+            go.Scatter(
+                x=data[dataset["key"]]["time"],
+                y=data[dataset["key"]]["average"],
+                name=dataset["name"],
+                line=dict(color=dataset["color"]),
+                mode="markers",
+                marker_size=3,
+            )
+        )
+
+    return plot
+
+
+plot = create_validation_plot(data=DATA_DAILY["series"])
 
 # Layout
 app.layout = html.Div(
@@ -84,15 +145,232 @@ app.layout = html.Div(
             style={"font-family": DEFAULT_FONT},
         ),
         table_daily,
+        html.Button("Save to Validated", id="daily-save-button"),
+        html.Button("Reset Validated", id="daily-reset-button"),
+        html.Div(
+            id="daily-status-message",
+            children=[""],
+            style={"font-family": DEFAULT_FONT},
+        ),
         html.H1(
             children="Detail of Selected Day",
             style={"font-family": DEFAULT_FONT},
         ),
         table_detail,
+        html.Button("Add row", id="detail-add-button"),
+        html.Button("Save to Validated", id="detail-save-button"),
+        html.Button("Reset Validated", id="detail-reset-button"),
+        html.Div(
+            id="detail-status-message",
+            children=[""],
+            style={"font-family": DEFAULT_FONT},
+        ),
         html.H1(
             children="Plot",
             style={"font-family": DEFAULT_FONT},
         ),
-        dcc.Graph(figure=plot),
+        dcc.Graph(id="plot", figure=plot),
     ]
 )
+
+
+@app.callback(
+    [
+        Output("daily-status-message", "children"),
+        Output("detail-status-message", "children"),
+        Output("plot", "figure"),
+        Output("table_daily", "rowData"),
+        Output("table_detail", "rowData"),
+        Output("table_detail", "rowTransaction"),
+        Output("table_detail", "scrollTo"),
+        Output("table_daily", "selectedRows"),
+        Output("table_detail", "selectedRows"),
+    ],
+    [
+        Input("daily-save-button", "n_clicks"),
+        Input("daily-reset-button", "n_clicks"),
+        Input("detail-save-button", "n_clicks"),
+        Input("detail-reset-button", "n_clicks"),
+        Input("detail-add-button", "n_clicks"),
+    ],
+    [
+        State("table_daily", "selectedRows"),
+        State("table_daily", "rowData"),
+        State("table_detail", "selectedRows"),
+        State("table_detail", "rowData"),
+    ],
+    prevent_initial_call=True,
+)
+def buttons_callback(
+    daily_save_clicks: int,
+    daily_reset_clicks: int,
+    detail_save_clicks: int,
+    detail_reset_clicks: int,
+    detail_add_clicks: int,
+    in_daily_selected_rows: list[dict],
+    in_daily_row_data: list[dict],
+    in_detail_selected_rows: list[dict],
+    in_detail_row_data: list[dict],
+) -> tuple[
+    str,
+    str,
+    go.Figure,
+    list[dict],
+    list[dict],
+    dict,
+    dict,
+    list[dict],
+    list[dict],
+]:
+    """Callback for buttons adding and resetting Validated data
+
+    Args:
+        daily_save_clicks (int): Number of times daily-save-button was clicked
+        daily_reset_clicks (int): Number of times daily-reset-button was clicked
+        detail_save_clicks (int): Number of times detail-save-button was clicked
+        detail_reset_clicks (int): Number of times detail-reset-button was clicked
+        detail_add_clicks (int): Number of times detail-add-button was clicked
+        in_daily_selected_rows (list[dict]): Selected rows in table_daily
+        in_detail_selected_rows (list[dict]): Selected rows in table_detail
+        in_detail_row_data (list[dict]): Full row data for table_detail
+
+    Returns:
+        tuple[str, str, go.Figure, list[dict], list[dict], dict, dict, list[dict], list[dict]]:
+            Callback outputs
+    """
+    global DATA_DAILY, DATA_DETAIL
+
+    ctx = dash.callback_context
+    button_id = ctx.triggered[0]["prop_id"].split(".")[0]
+
+    out_daily_status = dash.no_update
+    out_detail_status = dash.no_update
+    out_plot = dash.no_update
+    out_daily_row_data = dash.no_update
+    out_detail_row_data = dash.no_update
+    out_detail_row_transaction = dash.no_update
+    out_detail_scroll = dash.no_update
+    out_daily_selected_rows = dash.no_update
+    out_detail_selected_rows = dash.no_update
+
+    daily_refresh_required = False
+    detail_refresh_required = False
+    daily_reset_selection = False
+    detail_reset_selection = False
+    plot_refresh_required = False
+
+    # Button: Daily save
+    if button_id == "daily-save-button":
+        selected_ids = {row["id"] for row in in_daily_selected_rows}
+        for row in in_daily_row_data:
+            row["state"] = row["id"] in selected_ids
+        conditions = get_conditions(in_daily_row_data)
+        save_to_validated(
+            variable=VARIABLE,
+            station=STATION,
+            to_delete=conditions,
+            start_date=START_DATE,
+            end_date=END_DATE,
+            minimum=MINIMUM,
+            maximum=MAXIMUM,
+        )
+        out_daily_status = f"{len(in_daily_selected_rows)} days saved to Validated"
+        plot_refresh_required = True
+        daily_refresh_required = True
+
+    # Button: Daily reset
+    elif button_id == "daily-reset-button":
+        reset_daily_validated(
+            variable=VARIABLE,
+            station=STATION,
+            start_date=START_DATE,
+            end_date=END_DATE,
+        )
+        out_daily_status = "Validation reset"
+        plot_refresh_required = True
+        daily_refresh_required = True
+        daily_reset_selection = True
+
+    # Button: Detail save
+    elif button_id == "detail-save-button":
+        selected_ids = {row["id"] for row in in_detail_selected_rows}
+        for row in in_detail_row_data:
+            row["is_selected"] = row["id"] in selected_ids
+        save_detail_to_validated(
+            data_list=in_detail_row_data,
+            variable=VARIABLE,
+            station=STATION,
+        )
+        out_detail_status = f"{len(in_detail_selected_rows)} entries saved to Validated"
+        plot_refresh_required = True
+        detail_refresh_required = True
+
+    # Button: Detail reset
+    elif button_id == "detail-reset-button":
+        reset_detail_validated(
+            data_list=in_detail_row_data,
+            variable=VARIABLE,
+            station=STATION,
+        )
+        out_detail_status = "Validation reset"
+        plot_refresh_required = True
+        detail_refresh_required = True
+        detail_reset_selection = True
+
+    # Button: Detail new row
+    elif button_id == "detail-add-button":
+        last_id = in_detail_row_data[-1]["id"]
+        last_time = in_detail_row_data[-1]["time"]
+        new_row = {
+            "id": last_id + 1,
+            "time": last_time,
+            **{key: None for key in DATA_DAILY["value_columns"]},
+            "outlier": False,
+            "value_difference": None,
+            "is_selected": False,
+        }
+        out_detail_row_transaction = {"add": [new_row]}
+        out_detail_scroll = {"data": new_row}
+
+    # Refresh plot
+    if plot_refresh_required:
+        DATA_DAILY = daily_validation(
+            station=STATION,
+            variable=VARIABLE,
+            start_time=START_DATE,
+            end_time=END_DATE,
+            minimum=MINIMUM,
+            maximum=MAXIMUM,
+        )
+        out_plot = create_validation_plot(DATA_DAILY["series"])
+
+        # Refresh daily table
+        if daily_refresh_required:
+            out_daily_row_data = DATA_DAILY["data"]
+            if daily_reset_selection:
+                out_daily_selected_rows = out_daily_row_data
+
+    # Refresh detail table
+    if detail_refresh_required:
+        DATA_DETAIL = detail_list(
+            station=STATION,
+            variable=VARIABLE,
+            date_of_interest=SELECTED_DAY,
+            minimum=MINIMUM,
+            maximum=MAXIMUM,
+        )
+        out_detail_row_data = DATA_DETAIL["series"]
+        if detail_reset_selection:
+            out_detail_selected_rows = out_detail_row_data
+
+    return (
+        out_daily_status,
+        out_detail_status,
+        out_plot,
+        out_daily_row_data,
+        out_detail_row_data,
+        out_detail_row_transaction,
+        out_detail_scroll,
+        out_daily_selected_rows,
+        out_detail_selected_rows,
+    )

--- a/validated/dash_apps/finished_apps/daily_validation.py
+++ b/validated/dash_apps/finished_apps/daily_validation.py
@@ -1,15 +1,17 @@
 from datetime import datetime
 from decimal import Decimal
 
-import plotly.express as px
+import plotly.graph_objects as go
 from dash import dcc, html
 from django_plotly_dash import DjangoDash
 
 from station.models import Station
-from validated.functions import daily_validation
+from validated.functions import daily_validation, detail_list
+from validated.tables import create_daily_table, create_detail_table
 from variable.models import Variable
 
-# Create a Dash app
+DEFAULT_FONT = "Open Sans, Raleway, Dosis, Ubuntu, sans-serif"
+
 app = DjangoDash("DailyValidation")
 
 # Filters (in final app this will get data from forms)
@@ -20,7 +22,7 @@ end_time: datetime = datetime.strptime("2023-03-31", "%Y-%m-%d")
 minimum: Decimal = Decimal(-5)
 maximum: Decimal = Decimal(28)
 
-# Load data
+# Daily data
 data: dict = daily_validation(
     station=station,
     variable=variable,
@@ -30,10 +32,67 @@ data: dict = daily_validation(
     maximum=maximum,
 )
 
-# Create plot
-x = data["series"]["measurement"]["time"]
-y = data["series"]["measurement"]["average"]
-plot = px.line(x=x, y=y)
+# Detail data
+date: datetime = datetime.strptime("2023-03-14", "%Y-%m-%d")
+data_detail = detail_list(
+    station=station,
+    variable=variable,
+    date_of_interest=date,
+    minimum=minimum,
+    maximum=maximum,
+)
 
-# Create layout
-app.layout = html.Div([dcc.Graph(figure=plot)])
+# Tables
+table_daily = create_daily_table(data)
+table_detail = create_detail_table(data_detail)
+
+# Plot
+plot = go.Figure()
+plot.add_trace(
+    go.Scatter(
+        x=data["series"]["measurement"]["time"],
+        y=data["series"]["measurement"]["average"],
+        mode="lines",
+        name="Measurement",
+        line=dict(color="black"),
+    )
+)
+plot.add_trace(
+    go.Scatter(
+        x=data["series"]["selected"]["time"],
+        y=data["series"]["selected"]["average"],
+        mode="lines",
+        name="Selected",
+        line=dict(color="#636EFA"),
+    )
+)
+plot.add_trace(
+    go.Scatter(
+        x=data["series"]["validated"]["time"],
+        y=data["series"]["validated"]["average"],
+        mode="lines",
+        name="Validated",
+        line=dict(color="#00CC96"),
+    )
+)
+
+# Layout
+app.layout = html.Div(
+    children=[
+        html.H1(
+            children="Daily Report",
+            style={"font-family": DEFAULT_FONT},
+        ),
+        table_daily,
+        html.H1(
+            children="Detail of Selected Day",
+            style={"font-family": DEFAULT_FONT},
+        ),
+        table_detail,
+        html.H1(
+            children="Plot",
+            style={"font-family": DEFAULT_FONT},
+        ),
+        dcc.Graph(figure=plot),
+    ]
+)

--- a/validated/dash_apps/finished_apps/daily_validation.py
+++ b/validated/dash_apps/finished_apps/daily_validation.py
@@ -231,6 +231,10 @@ app.layout = html.Div(
                 "padding-bottom": "10px",
             },
         ),
+        dcc.Loading(
+            type="dot",
+            children=html.Div(id="loading"),
+        ),
         plot_radio,
         dcc.Graph(id="plot", figure=plot, style={"width": "100%"}),
     ]
@@ -239,6 +243,7 @@ app.layout = html.Div(
 
 @app.callback(
     [
+        Output("loading", "children"),
         Output("status-message", "children"),
         Output("plot", "figure"),
         Output("table_daily", "rowData"),
@@ -282,6 +287,7 @@ def callbacks(
     in_detail_row_data: list[dict],
 ) -> tuple[
     str,
+    str,
     go.Figure,
     list[dict],
     list[dict],
@@ -308,7 +314,7 @@ def callbacks(
         in_detail_row_data (list[dict]): Full row data for table_detail
 
     Returns:
-        tuple[str, go.Figure, list[dict], list[dict], dict, dict, list[dict], list[dict], bool, str, str]:
+        tuple[str, str, go.Figure, list[dict], list[dict], dict, dict, list[dict], list[dict], bool, str, str]:
             Callback outputs
     """
     global DATA_DAILY, DATA_DETAIL, SELECTED_DAY, PLOT_TYPE
@@ -316,6 +322,7 @@ def callbacks(
     ctx = dash.callback_context
     button_id = ctx.triggered[0]["prop_id"].split(".")[0]
 
+    out_loading = dash.no_update
     out_status = dash.no_update
     out_plot = dash.no_update
     out_daily_row_data = dash.no_update
@@ -482,6 +489,7 @@ def callbacks(
             out_detail_selected_rows = out_detail_row_data
 
     return (
+        out_loading,
         out_status,
         out_plot,
         out_daily_row_data,

--- a/validated/dash_apps/finished_apps/daily_validation.py
+++ b/validated/dash_apps/finished_apps/daily_validation.py
@@ -105,36 +105,41 @@ table_detail = AgGrid(
 )
 
 
-# Menus
-menu_daily = html.Div(
+# Date picker
+detail_date_picker = html.Div(
+    children=[
+        html.Div(
+            children=["Open detailed view"],
+            style={
+                "display": "inline-block",
+                "font-family": DEFAULT_FONT,
+                "padding-right": "5px",
+                "font-size": "14px",
+            },
+        ),
+        dcc.DatePickerSingle(
+            id="detail-date-picker",
+            display_format="YYYY-MM-DD",
+            min_date_allowed=DATA_DAILY["data"][0]["date"],
+            max_date_allowed=DATA_DAILY["data"][-1]["date"],
+            style={"font-family": DEFAULT_FONT},
+        ),
+    ],
+    style={"display": "inline-block", "width": "50%", "text-align": "right"},
+)
+
+# Menu
+menu = html.Div(
     children=[
         html.Div(
             children=[
-                html.Button("Save to Validated", id="daily-save-button"),
-                html.Button("Reset Validated", id="daily-reset-button"),
+                html.Button("Save to Validated", id="save-button"),
+                html.Button("Reset Validated", id="reset-button"),
+                html.Button("Add row", id="add-button", disabled=True),
             ],
             style={"display": "inline-block", "width": "50%"},
         ),
-        html.Div(
-            children=[
-                html.Div(
-                    children=["Open detailed view"],
-                    style={
-                        "display": "inline-block",
-                        "font-family": DEFAULT_FONT,
-                        "padding-right": "5px",
-                        "font-size": "14px",
-                    },
-                ),
-                dcc.Input(
-                    id="input-daily-id",
-                    type="number",
-                    debounce=True,
-                    placeholder="ID",
-                ),
-            ],
-            style={"display": "inline-block", "width": "50%", "text-align": "right"},
-        ),
+        detail_date_picker,
     ],
     style={
         "background-color": "#f0f0f0",
@@ -142,32 +147,16 @@ menu_daily = html.Div(
     },
 )
 
-menu_detail = html.Div(
-    children=[
-        html.Div(
-            children=[
-                html.Button("Save to Validated", id="detail-save-button"),
-                html.Button("Reset Validated", id="detail-reset-button"),
-            ],
-            style={
-                "display": "inline-block",
-                "width": "50%",
-            },
-        ),
-        html.Div(
-            children=[
-                html.Button("Add row", id="detail-add-button"),
-            ],
-            style={
-                "display": "inline-block",
-                "text-align": "right",
-                "width": "50%",
-            },
-        ),
-    ],
+# Status message
+status_message = html.Div(
+    id="status-message",
+    children=[""],
     style={
-        "background-color": "#f0f0f0",
-        "width": "100%",
+        "font-family": DEFAULT_FONT,
+        "font-size": "14px",
+        "min-height": "20px",
+        "padding-top": "5px",
+        "padding-bottom": "10px",
     },
 )
 
@@ -202,7 +191,6 @@ app.layout = html.Div(
                     selected_style={"font-family": DEFAULT_FONT},
                     children=[
                         table_daily,
-                        menu_daily,
                     ],
                 ),
                 dcc.Tab(
@@ -215,22 +203,12 @@ app.layout = html.Div(
                     disabled_style={"font-family": DEFAULT_FONT},
                     children=[
                         table_detail,
-                        menu_detail,
                     ],
                 ),
             ],
         ),
-        html.Div(
-            id="status-message",
-            children=[""],
-            style={
-                "font-family": DEFAULT_FONT,
-                "font-size": "14px",
-                "min-height": "20px",
-                "padding-top": "5px",
-                "padding-bottom": "10px",
-            },
-        ),
+        menu,
+        status_message,
         dcc.Loading(
             type="dot",
             children=html.Div(id="loading"),
@@ -255,15 +233,15 @@ app.layout = html.Div(
         Output("tab-detail", "disabled"),
         Output("tab-detail", "label"),
         Output("tabs", "value"),
+        Output("add-button", "disabled"),
     ],
     [
-        Input("daily-save-button", "n_clicks"),
-        Input("daily-reset-button", "n_clicks"),
-        Input("detail-save-button", "n_clicks"),
-        Input("detail-reset-button", "n_clicks"),
-        Input("detail-add-button", "n_clicks"),
-        Input("input-daily-id", "value"),
+        Input("save-button", "n_clicks"),
+        Input("reset-button", "n_clicks"),
+        Input("add-button", "n_clicks"),
+        Input("detail-date-picker", "date"),
         Input("plot_radio", "value"),
+        Input("tabs", "value"),
     ],
     [
         State("table_daily", "selectedRows"),
@@ -274,13 +252,12 @@ app.layout = html.Div(
     prevent_initial_call=True,
 )
 def callbacks(
-    daily_save_clicks: int,
-    daily_reset_clicks: int,
-    detail_save_clicks: int,
-    detail_reset_clicks: int,
-    detail_add_clicks: int,
-    daily_id: int,
+    save_clicks: int,
+    reset_clicks: int,
+    add_clicks: int,
+    detail_date: datetime.date,
     plot_radio_value: str,
+    tabs_value: str,
     in_daily_selected_rows: list[dict],
     in_daily_row_data: list[dict],
     in_detail_selected_rows: list[dict],
@@ -298,6 +275,7 @@ def callbacks(
     bool,
     str,
     str,
+    bool,
 ]:
     """Callback for buttons adding and resetting Validated data
 
@@ -334,6 +312,7 @@ def callbacks(
     out_tab_detail_disabled = dash.no_update
     out_tab_detail_label = dash.no_update
     out_tabs_value = dash.no_update
+    out_add_button_disabled = dash.no_update
 
     daily_data_refresh_required = False
     detail_data_refresh_required = False
@@ -343,8 +322,8 @@ def callbacks(
     detail_table_reset_selection = False
     plot_refresh_required = False
 
-    # Button: Daily save
-    if button_id == "daily-save-button":
+    # Button: Save (daily)
+    if button_id == "save-button" and tabs_value == "tab-daily":
         selected_ids = {row["id"] for row in in_daily_selected_rows}
         for row in in_daily_row_data:
             row["state"] = row["id"] in selected_ids
@@ -363,22 +342,8 @@ def callbacks(
         daily_table_refresh_required = True
         plot_refresh_required = True
 
-    # Button: Daily reset
-    elif button_id == "daily-reset-button":
-        reset_daily_validated(
-            variable=VARIABLE,
-            station=STATION,
-            start_date=START_DATE,
-            end_date=END_DATE,
-        )
-        out_status = "Validation reset"
-        daily_data_refresh_required = True
-        daily_table_refresh_required = True
-        daily_table_reset_selection = True
-        plot_refresh_required = True
-
-    # Button: Detail save
-    elif button_id == "detail-save-button":
+    # Button: Save (detail)
+    elif button_id == "save-button" and tabs_value == "tab-detail":
         selected_ids = {row["id"] for row in in_detail_selected_rows}
         for row in in_detail_row_data:
             row["is_selected"] = row["id"] in selected_ids
@@ -394,8 +359,22 @@ def callbacks(
         detail_table_refresh_required = True
         plot_refresh_required = True
 
-    # Button: Detail reset
-    elif button_id == "detail-reset-button":
+    # Button: Reset (daily)
+    elif button_id == "reset-button" and tabs_value == "tab-daily":
+        reset_daily_validated(
+            variable=VARIABLE,
+            station=STATION,
+            start_date=START_DATE,
+            end_date=END_DATE,
+        )
+        out_status = "Validation reset"
+        daily_data_refresh_required = True
+        daily_table_refresh_required = True
+        daily_table_reset_selection = True
+        plot_refresh_required = True
+
+    # Button: Reset (detail)
+    elif button_id == "reset-button" and tabs_value == "tab-detail":
         reset_detail_validated(
             data_list=in_detail_row_data,
             variable=VARIABLE,
@@ -409,8 +388,8 @@ def callbacks(
         detail_table_reset_selection = True
         plot_refresh_required = True
 
-    # Button: Detail new row
-    elif button_id == "detail-add-button":
+    # Button: New row (detail)
+    elif button_id == "add-button" and tabs_value == "tab-detail":
         last_id = in_detail_row_data[-1]["id"]
         last_time = in_detail_row_data[-1]["time"]
         new_row = {
@@ -424,20 +403,27 @@ def callbacks(
         out_detail_row_transaction = {"add": [new_row]}
         out_detail_scroll = {"data": new_row}
 
-    # Input: Daily ID
-    elif button_id == "input-daily-id":
-        SELECTED_DAY = next(
-            (d["date"] for d in DATA_DAILY["data"] if d["id"] == daily_id),
-            dash.no_update,
+    # Date picker
+    elif button_id == "detail-date-picker":
+        new_selected_day = next(
+            (
+                d["date"]
+                for d in DATA_DAILY["data"]
+                if d["date"].strftime("%Y-%m-%d") == detail_date
+            ),
+            None,
         )
-        if SELECTED_DAY != dash.no_update:
+        if new_selected_day is not None:
+            SELECTED_DAY = new_selected_day
             detail_data_refresh_required = True
             detail_table_refresh_required = True
+            detail_table_reset_selection = True
             out_tab_detail_disabled = False
             out_tab_detail_label = (
                 f"Detail of Selected Day ({SELECTED_DAY.strftime('%Y-%m-%d')})"
             )
             out_tabs_value = "tab-detail"
+            out_add_button_disabled = False
             out_status = ""
         else:
             out_status = "Invalid ID"
@@ -446,6 +432,13 @@ def callbacks(
     elif button_id == "plot_radio":
         PLOT_TYPE = plot_radio_value
         plot_refresh_required = True
+
+    # Switching tabs
+    elif button_id == "tabs":
+        if tabs_value == "tab-detail":
+            out_add_button_disabled = False
+        else:
+            out_add_button_disabled = True
 
     # Reload daily data
     if daily_data_refresh_required:
@@ -501,4 +494,5 @@ def callbacks(
         out_tab_detail_disabled,
         out_tab_detail_label,
         out_tabs_value,
+        out_add_button_disabled,
     )

--- a/validated/plots.py
+++ b/validated/plots.py
@@ -1,0 +1,56 @@
+import plotly.graph_objects as go
+
+
+def create_validation_plot(data: dict, plot_type: str) -> go.Figure:
+    """Creates plot for Validation app
+
+    Args:
+        data (dict): Daily data
+        plot_type (str): Type of plot
+
+    Returns:
+        go.Figure: Plot
+    """
+    variable: str = data["variable"]["name"]
+    data_series: dict = data["series"]
+    is_cumulative: bool = data["variable"]["is_cumulative"]
+    mode = "lines" if is_cumulative else "markers"
+
+    fig = go.Figure()
+
+    datasets = [
+        {"key": "measurement", "name": "Measurement", "color": "black"},
+        {"key": "selected", "name": "Selected", "color": "#636EFA"},
+        {"key": "validated", "name": "Validated", "color": "#00CC96"},
+    ]
+
+    for dataset in datasets:
+        fig.add_trace(
+            go.Scatter(
+                x=data_series[dataset["key"]]["time"],
+                y=data_series[dataset["key"]][plot_type],
+                name=dataset["name"],
+                line=dict(color=dataset["color"]),
+                mode=mode,
+                marker_size=3,
+            )
+        )
+
+    fig.update_yaxes(title_text=f"{variable} ({plot_type.capitalize()})")
+    fig.update_layout(
+        legend=dict(
+            x=1,
+            y=1,
+            xanchor="auto",
+            yanchor="auto",
+        ),
+        autosize=True,
+        margin=dict(
+            l=50,
+            r=0,
+            b=0,
+            t=20,
+        ),
+    )
+
+    return fig

--- a/validated/tables.py
+++ b/validated/tables.py
@@ -1,0 +1,287 @@
+from dash_ag_grid import AgGrid
+
+
+def create_daily_table(data: dict) -> AgGrid:
+    """Creates Daily Report table
+
+    Args:
+        data (dict): Daily report data (from functions.daily_validation)
+
+    Returns:
+        AgGrid: Daily report table
+    """
+    table = AgGrid(
+        id="table_daily",
+        rowData=data["data"],
+        columnDefs=create_columns_daily(value_columns=data["value_columns"]),
+        columnSize="sizeToFit",
+        defaultColDef={
+            "resizable": True,
+            "sortable": True,
+            "checkboxSelection": {
+                "function": "params.column == params.columnApi.getAllDisplayedColumns()[0]"
+            },
+            "headerCheckboxSelection": {
+                "function": "params.column == params.columnApi.getAllDisplayedColumns()[0]"
+            },
+            "headerCheckboxSelectionFilteredOnly": True,
+        },
+        dashGridOptions={"rowSelection": "multiple", "suppressRowClickSelection": True},
+        selectAll=True,
+    )
+    return table
+
+
+def create_detail_table(data: dict) -> AgGrid:
+    """Creates Detail table for a specific date
+
+    Args:
+        data (dict): Detail data (from functions.detail_list)
+
+    Returns:
+        AgGrid: Detail table
+    """
+    table = AgGrid(
+        id="table_detail",
+        rowData=data["series"],
+        columnDefs=create_columns_detail(value_columns=data["value_columns"]),
+        columnSize="sizeToFit",
+        defaultColDef={
+            "resizable": True,
+            "sortable": True,
+            "checkboxSelection": {
+                "function": "params.column == params.columnApi.getAllDisplayedColumns()[0]"
+            },
+            "headerCheckboxSelection": {
+                "function": "params.column == params.columnApi.getAllDisplayedColumns()[0]"
+            },
+            "headerCheckboxSelectionFilteredOnly": True,
+        },
+        dashGridOptions={"rowSelection": "multiple", "suppressRowClickSelection": True},
+        selectAll=True,
+    )
+    return table
+
+
+def create_columns_daily(value_columns: list) -> list:
+    """Creates columns for Daily Report table
+
+    Args:
+        value_columns (list): List of value columns
+
+    Returns:
+        list: List of columns
+    """
+    styles = create_style_conditions_daily()
+
+    columns = [
+        {
+            "field": "id",
+            "headerName": "Id",
+            "filter": "agNumberColumnFilter",
+            "maxWidth": 150,
+        },
+        {
+            "valueGetter": {"function": "d3.timeParse('%Y-%m-%d')(params.data.date)"},
+            "headerName": "Date",
+            "filter": "agDateColumnFilter",
+            "valueFormatter": {"function": "params.data.date"},
+            **styles["date"],
+        },
+        {
+            "field": "percentage",
+            "headerName": "Percnt.",
+            "filter": "agNumberColumnFilter",
+            **styles["percentage"],
+        },
+    ]
+
+    additional_columns = [
+        {
+            "field": "sum",
+            "headerName": "Sum",
+            "filter": "agNumberColumnFilter",
+            **styles["sum"],
+        },
+        {
+            "field": "average",
+            "headerName": "Average",
+            "filter": "agNumberColumnFilter",
+            **styles["average"],
+        },
+        {
+            "field": "maximum",
+            "headerName": "Max. of Maxs.",
+            "filter": "agNumberColumnFilter",
+            **styles["maximum"],
+        },
+        {
+            "field": "minimum",
+            "headerName": "Min. of Mins.",
+            "filter": "agNumberColumnFilter",
+            **styles["minimum"],
+        },
+    ]
+
+    columns += [d for d in additional_columns if d["field"] in value_columns]
+
+    columns += [
+        {
+            "field": "value_difference_error_count",
+            "headerName": "Diff. Err",
+            "filter": "agNumberColumnFilter",
+            **styles["value_difference_error_count"],
+        },
+    ]
+    return columns
+
+
+def create_columns_detail(value_columns: list) -> list:
+    """Creates columns for Detail table
+
+    Args:
+        value_columns (list): List of value columns
+
+    Returns:
+        list: List of columns
+    """
+    styles = create_style_conditions_detail(value_columns)
+
+    columns = [
+        {
+            "field": "id",
+            "headerName": "Id",
+            "filter": "agNumberColumnFilter",
+            "maxWidth": 150,
+        },
+        {
+            "field": "time",
+            "valueFormatter": {"function": "params.value.split('T')[1].split('+')[0]"},
+            "headerName": "Time",
+            **styles["time"],
+        },
+    ]
+    columns += [
+        {
+            "field": c,
+            "headerName": c[0].upper() + c[1:],
+            "filter": "agNumberColumnFilter",
+            "editable": True,
+            **styles[c],
+        }
+        for c in value_columns
+    ]
+    columns += [
+        {
+            "field": "stdev_error",
+            "headerName": "Outliers",
+            "valueFormatter": {"function": "params.value ? 'X' : '-'"},
+        },
+        {"field": "value_difference", "headerName": "Value diff."},
+    ]
+    return columns
+
+
+def create_style_conditions_daily() -> dict:
+    """Creates style conditions for Daily Report table
+
+    Returns:
+        dict: Style conditions
+    """
+    styles = {}
+
+    styles["id"] = {
+        "cellStyle": {
+            "styleConditions": [
+                {
+                    "condition": "params.data['all_validated']",
+                    "style": {"backgroundColor": "#00CC96"},
+                },
+            ]
+        },
+    }
+
+    styles["date"] = {
+        "cellStyle": {
+            "styleConditions": [
+                {
+                    "condition": "params.data['date_error'] > 0",
+                    "style": {"backgroundColor": "#E45756"},
+                },
+            ]
+        },
+    }
+
+    styles["percentage"] = {
+        "cellStyle": {
+            "styleConditions": [
+                {
+                    "condition": "params.data['percentage_error']",
+                    "style": {"backgroundColor": "#E45756"},
+                },
+            ]
+        },
+    }
+
+    styles["value_difference_error_count"] = {
+        "cellStyle": {
+            "styleConditions": [
+                {
+                    "condition": "params.data['value_difference_error_count'] > 0",
+                    "style": {"backgroundColor": "#E45756"},
+                },
+            ]
+        },
+    }
+
+    for field in ["sum", "average", "maximum", "minimum"]:
+        styles[field] = {
+            "cellStyle": {
+                "styleConditions": [
+                    {
+                        "condition": f"params.data['suspicious_{field}s_count'] > 0",
+                        "style": {"backgroundColor": "#E45756"},
+                    },
+                ]
+            },
+        }
+
+    return styles
+
+
+def create_style_conditions_detail(value_columns: list) -> dict:
+    """Creates style conditions for Detail table
+
+    Args:
+        value_columns (list): List of value columns
+
+    Returns:
+        dict: Style conditions
+    """
+    styles = {}
+
+    styles["time"] = {
+        "cellStyle": {
+            "styleConditions": [
+                {
+                    "condition": f"params.data['time_lapse_status'] == {val}",
+                    "style": {"backgroundColor": f"{col}"},
+                }
+                for val, col in zip([0, 2], ["#E45756", "#FFA15A"])
+            ]
+        },
+    }
+
+    for field in value_columns + ["stdev", "value_difference"]:
+        styles[field] = {
+            "cellStyle": {
+                "styleConditions": [
+                    {
+                        "condition": f"params.data['{field}_error']",
+                        "style": {"backgroundColor": "#E45756"},
+                    },
+                ]
+            },
+        }
+
+    return styles

--- a/validated/tables.py
+++ b/validated/tables.py
@@ -106,7 +106,7 @@ def create_columns_detail(value_columns: list) -> list:
     columns += [
         {
             "field": c,
-            "headerName": c[0].upper() + c[1:],
+            "headerName": c.capitalize(),
             "filter": "agNumberColumnFilter",
             "editable": True,
             **styles[c],


### PR DESCRIPTION
Creates a dash app to visualise data in tabular and graph form, and manually save to the Validated dataset. Replicates the original Daily Validation Javascript app (http://localhost:8000/validated/daily_validation/). 

The new app is a self-contained page accessible at http://localhost:8000/validated/daily_validation_dev/

For now, the data filters are specified in the code, although eventually we will want to include these as drop downs on the page (either through the existing django forms or new dash objects).

---

I'm keeping this as a master branch for #121, and merging PRs into this branch as I add new features.

PRs already merged:
#143 Making a start on the tables, showing the appropriate data, conditional styling
#145 Callbacks for adding new data and saving to validated
#151 Arranging tables into tabs and callback for opening the detailed view table
#154 Cosmetic improvements to the plot, and radio selector for choosing which information to show
#158 Date picker for choosing date for detail table
#159 Adds data filters to the top (replacing django form functionality)

---

Notes/remaining issues:
- Daily data and detail data doesn't seem to match up. For example, the Max of maxs. for 2023-03-14 is shown as 50.34, but looking at the detailed view for that day the highest maximum value is 17.42. This is the same in the original JS app. Am I just misunderstanding something?
- The buttons are sometimes very laggy, especially the 'Save to Validated' and 'Reset Validated' buttons which require calls to the database. (This seems to vary a lot though, and could relate to developing the code while it's running.)
- ~~Related to the above, the original app brings up loading messages while the button callbacks are running. This would be a good thing to do here given how long some of the callbacks take, but I haven't yet found an easy way to do this.~~ Done
- I'm unsure what the 'Selected' component of the data is meant to represent. Is this just to represent which measurements are selected in the tables? If so, why does Selected deviate from Measurement in the plot (see 30th March)
- The plot only updates when buttons are pressed, so selecting rows in the tables won't change the Selected dots in the plot until a button is pressed. This is the same as the JS app. 
- Why is there no data for March 31st?
- Why do days run from 5am-5am? Is this a timezone thing?
- Probably related to the above two, but opening detail view for April 1st gives 'No Rows To Show' (same in the JS app)
- ~~Fonts: I'm defining the default font at the top as a string, and then passing this as a style attribute to every text object. This works, but presumably there's a way of globally defining the default font for the app?~~ Edit: fixed using stylesheet
- Layout: I like being able to view the tables and the plot at the same time, but ideally they would both fit on the screen without having to scroll. I was having issues defining the height of individual divs so probably doing something wrong. I also don't know how to deal with potentially different screen sizes.
- There's a load of white space at the bottom which I don't know how to get rid of.
- We will need to add authentication somewhere so it only works for logged-in users.
- Filters at the top won't show an error message if invalid filters are selected and just won't update the tables/plot. However, this should be fixed when we address #108 
- In the js app the filters automatically fill in the min/max values once the station, variable and dates are selected, however I can't find where in the code this is done, so I haven't been able to replicate it here.