### PR TITLE
Use date picker to specify date for detail table

### DIFF
--- a/validated/dash_apps/finished_apps/daily_validation.py
+++ b/validated/dash_apps/finished_apps/daily_validation.py
@@ -126,11 +126,12 @@ menu_daily = html.Div(
                         "font-size": "14px",
                     },
                 ),
-                dcc.Input(
-                    id="input-daily-id",
-                    type="number",
-                    debounce=True,
-                    placeholder="ID",
+                dcc.DatePickerSingle(
+                    id="detail-date-picker",
+                    display_format="YYYY-MM-DD",
+                    min_date_allowed=DATA_DAILY["data"][0]["date"],
+                    max_date_allowed=DATA_DAILY["data"][-1]["date"],
+                    style={"font-family": DEFAULT_FONT},
                 ),
             ],
             style={"display": "inline-block", "width": "50%", "text-align": "right"},
@@ -262,7 +263,7 @@ app.layout = html.Div(
         Input("detail-save-button", "n_clicks"),
         Input("detail-reset-button", "n_clicks"),
         Input("detail-add-button", "n_clicks"),
-        Input("input-daily-id", "value"),
+        Input("detail-date-picker", "date"),
         Input("plot_radio", "value"),
     ],
     [
@@ -279,7 +280,7 @@ def callbacks(
     detail_save_clicks: int,
     detail_reset_clicks: int,
     detail_add_clicks: int,
-    daily_id: int,
+    detail_date: datetime.date,
     plot_radio_value: str,
     in_daily_selected_rows: list[dict],
     in_daily_row_data: list[dict],
@@ -424,13 +425,18 @@ def callbacks(
         out_detail_row_transaction = {"add": [new_row]}
         out_detail_scroll = {"data": new_row}
 
-    # Input: Daily ID
-    elif button_id == "input-daily-id":
-        SELECTED_DAY = next(
-            (d["date"] for d in DATA_DAILY["data"] if d["id"] == daily_id),
-            dash.no_update,
+    # Date picker
+    elif button_id == "detail-date-picker":
+        new_selected_day = next(
+            (
+                d["date"]
+                for d in DATA_DAILY["data"]
+                if d["date"].strftime("%Y-%m-%d") == detail_date
+            ),
+            None,
         )
-        if SELECTED_DAY != dash.no_update:
+        if new_selected_day is not None:
+            SELECTED_DAY = new_selected_day
             detail_data_refresh_required = True
             detail_table_refresh_required = True
             out_tab_detail_disabled = False

--- a/validated/dash_apps/finished_apps/daily_validation.py
+++ b/validated/dash_apps/finished_apps/daily_validation.py
@@ -135,7 +135,7 @@ menu = html.Div(
             children=[
                 html.Button("Save to Validated", id="save-button"),
                 html.Button("Reset Validated", id="reset-button"),
-                html.Button("Add row", id="add-button", style={"display": "none"}),
+                html.Button("Add row", id="add-button", disabled=True),
             ],
             style={"display": "inline-block", "width": "50%"},
         ),
@@ -148,19 +148,18 @@ menu = html.Div(
 )
 
 # Status message
-status_message = (
-    html.Div(
-        id="status-message",
-        children=[""],
-        style={
-            "font-family": DEFAULT_FONT,
-            "font-size": "14px",
-            "min-height": "20px",
-            "padding-top": "5px",
-            "padding-bottom": "10px",
-        },
-    ),
+status_message = html.Div(
+    id="status-message",
+    children=[""],
+    style={
+        "font-family": DEFAULT_FONT,
+        "font-size": "14px",
+        "min-height": "20px",
+        "padding-top": "5px",
+        "padding-bottom": "10px",
+    },
 )
+
 
 # Plot
 plot = create_validation_plot(data=DATA_DAILY, plot_type=PLOT_TYPE)
@@ -234,7 +233,7 @@ app.layout = html.Div(
         Output("tab-detail", "disabled"),
         Output("tab-detail", "label"),
         Output("tabs", "value"),
-        Output("add-button", "style"),
+        Output("add-button", "disabled"),
     ],
     [
         Input("save-button", "n_clicks"),
@@ -276,6 +275,7 @@ def callbacks(
     bool,
     str,
     str,
+    bool,
 ]:
     """Callback for buttons adding and resetting Validated data
 
@@ -312,7 +312,7 @@ def callbacks(
     out_tab_detail_disabled = dash.no_update
     out_tab_detail_label = dash.no_update
     out_tabs_value = dash.no_update
-    out_add_button_style = dash.no_update
+    out_add_button_disabled = dash.no_update
 
     daily_data_refresh_required = False
     detail_data_refresh_required = False
@@ -423,7 +423,7 @@ def callbacks(
                 f"Detail of Selected Day ({SELECTED_DAY.strftime('%Y-%m-%d')})"
             )
             out_tabs_value = "tab-detail"
-            out_add_button_style = {"display": "inline-block"}
+            out_add_button_disabled = False
             out_status = ""
         else:
             out_status = "Invalid ID"
@@ -436,9 +436,9 @@ def callbacks(
     # Switching tabs
     elif button_id == "tabs":
         if tabs_value == "tab-detail":
-            out_add_button_style = {"display": "inline-block"}
+            out_add_button_disabled = False
         else:
-            out_add_button_style = {"display": "none"}
+            out_add_button_disabled = True
 
     # Reload daily data
     if daily_data_refresh_required:
@@ -494,5 +494,5 @@ def callbacks(
         out_tab_detail_disabled,
         out_tab_detail_label,
         out_tabs_value,
-        out_add_button_style,
+        out_add_button_disabled,
     )


### PR DESCRIPTION
This adds a date picker to the bar at the bottom of the tables which can be used to choose a date for the detail view, rather than the numerical input that was used before.

I've also moved the bar outside of the tabs so now a single bar is shared between between both tables, with logic added to the callback to change the behaviour of the buttons depending on which tab is selected.