### PR TITLE
Publish Paricia as a docker container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,3 +43,31 @@ jobs:
       run: python manage.py migrate
     - name: Run tests
       run: python manage.py test -v 2
+      
+  publish:
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/develop'
+    needs: test
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v1
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+        
+    - name: Get image metadata
+      id: meta
+      uses: docker/metadata-action@v3
+      with:
+        images: ghcr.io/${{ github.repository }}
+        
+    - name: Build and push Docker image for the web app
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
Publishes Paricia in the GitHub package registry as a docker container, so it can be deployed anywhere else easily. 

When we're ready to go to production, this should run only when there's a new release. For now, during development, this will run anytime we make a push to the `develop` branch to allow for quickly testing changes.

Contributes to #142 