### PR TITLE
Launch reports when saving or resetting validation

### DIFF
--- a/measurement/validation.py
+++ b/measurement/validation.py
@@ -288,14 +288,11 @@ def reset_validated_entries(ids: list) -> None:
         ids (list): List of measurement ids to reset.
     """
     times = []
-    update = {"is_validated": False, "is_active": True}
     for _id in ids:
         current = Measurement.objects.get(id=_id)
         current.is_validated = False
         current.is_active = True
         current.save()
-        times.append(current.time)
-        current.update(**update)
         times.append(current.time)
 
     station = current.station.station_code

--- a/measurement/validation.py
+++ b/measurement/validation.py
@@ -290,7 +290,11 @@ def reset_validated_entries(ids: list) -> None:
     times = []
     update = {"is_validated": False, "is_active": True}
     for _id in ids:
-        current = Measurement.objects.filter(id=_id)
+        current = Measurement.objects.get(id=_id)
+        current.is_validated = False
+        current.is_active = True
+        current.save()
+        times.append(current.time)
         current.update(**update)
         times.append(current.time)
 

--- a/tests/measurement/test_validation.py
+++ b/tests/measurement/test_validation.py
@@ -342,7 +342,6 @@ class TestValidationFunctions(TestCase):
         data = pd.DataFrame(
             {
                 "id": [1, 2, 3],
-                "time": ["2023-01-01", "2023-01-02", "2023-01-03"],
                 "value": [10.0, 20.0, 30.0],
                 "maximum": [15.0, 25.0, 35.0],
                 "minimum": [5.0, 15.0, 25.0],
@@ -392,8 +391,20 @@ class TestValidationFunctions(TestCase):
         measurement_2.save()
         measurement_3.save()
 
+        launch_report_mock = self.create_patch(
+            "measurement.reporting.launch_reports_calculation"
+        )
+
         # Call the function under test
         save_validated_entries(data)
+
+        # Assert the expected call to the launch_report_calculation function
+        launch_report_mock.assert_called_once_with(
+            self.station.station_code,
+            self.variable.variable_code,
+            measurement_1.time.strftime("%Y-%m-%d"),
+            measurement_3.time.strftime("%Y-%m-%d"),
+        )
 
         # Retrieve the updated Measurement objects
         updated_measurement_1 = Measurement.objects.get(id=1)
@@ -446,8 +457,20 @@ class TestValidationFunctions(TestCase):
             mock_query_set = MockQuerySet()
             mock_filter.return_value = mock_query_set
 
+            launch_report_mock = self.create_patch(
+                "measurement.reporting.launch_reports_calculation"
+            )
+
             # Call the function under test
             save_validated_days(data)
+
+            # Assert the expected call to the launch_report_calculation function
+            launch_report_mock.assert_called_once_with(
+                "station1",
+                "variable1",
+                "2023-01-01",
+                "2023-01-01",
+            )
 
             # Assert that the filter method was called with the correct arguments
             mock_filter.assert_called_once_with(


### PR DESCRIPTION
Launches the calculation of the reports when saving the validated data, either when saving days or when saving individual entries. It also deletes reports data in the relevant time range when resetting validation.

Fixes #208 