### PR TITLE
Fix bugs in admin classes

### DIFF
--- a/management/admin.py
+++ b/management/admin.py
@@ -1,10 +1,9 @@
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin
 from django.core.exceptions import PermissionDenied
-from django.db.models import Q
 from django.utils.translation import gettext_lazy as _
 from guardian.admin import GuardedModelAdmin
-from guardian.shortcuts import get_perms
+from guardian.shortcuts import get_objects_for_user, get_perms
 
 from .models import User
 
@@ -39,7 +38,7 @@ class PermissionsBaseAdmin(GuardedModelAdmin):
     def formfield_for_foreignkey(self, db_field, request, **kwargs):
         """Limit the queryset for foreign key fields."""
         if db_field.name in self.foreign_key_fields:
-            kwargs["queryset"] = _get_queryset(db_field.related_model, request.user)
+            kwargs["queryset"] = _get_queryset(db_field, request.user)
         if db_field.name == "owner":
             kwargs["initial"] = request.user.id
             kwargs["disabled"] = True
@@ -48,20 +47,29 @@ class PermissionsBaseAdmin(GuardedModelAdmin):
     def save_model(self, request, obj, form, change):
         """Check if the user has the correct permissions to save the object."""
         for field in self.foreign_key_fields:
-            owner = getattr(obj, field).owner
-            perm_level = getattr(obj, field).permissions_level
-            if owner != request.user and perm_level == "Private":
+            related_obj = getattr(obj, field)
+            if related_obj is None:
+                continue
+            if (
+                related_obj.permissions_level == "Private"
+                and f"change_{field}" not in get_perms(request.user, obj)
+            ):
                 raise PermissionDenied(f"Private {field}: Only owner can use.")
         super().save_model(request, obj, form, change)
 
 
-def _get_queryset(model, user):
+def _get_queryset(db_field, user):
     """Return a queryset based on the permissions of the user.
 
-    Returns all public objects plus any objects owned by the user.
+    Returns queryset of public objects and objects that the user has change permisions
+    for.
 
     """
-    return model.objects.filter(Q(owner=user) | Q(permissions_level="Public"))
+    app_name = db_field.related_model._meta.app_label
+    model_name = db_field.related_model._meta.model_name
+    user_objects = get_objects_for_user(user, f"{app_name}.change_{model_name}")
+    public_objects = db_field.related_model.objects.filter(permissions_level="Public")
+    return user_objects | public_objects
 
 
 class CustomUserAdmin(UserAdmin):


### PR DESCRIPTION
This fixes some bugs in the admin classes which should allow superusers to add and change objects without problems.
- previously permissions were being checked by checking object ownership rather than the actual permissions attributes, which obviously won't work for superusers
- there were issues before if any objects didn't have an owner. Long term we will make object ownership mandatory, but until then this should fix those problems

There will still be issues with add permissions for non-superusers.