### PR TITLE
Make admin work for standard users

### DIFF
--- a/management/admin.py
+++ b/management/admin.py
@@ -35,6 +35,13 @@ class PermissionsBaseAdmin(GuardedModelAdmin):
             return f"view_{self.opts.model_name}" in get_perms(request.user, obj)
         return True
 
+    def get_queryset(self, request):
+        """Return a queryset of the objects that the user has view permissions for."""
+        qs = super().get_queryset(request)
+        return get_objects_for_user(
+            request.user, f"{self.opts.app_label}.view_{self.opts.model_name}", qs
+        )
+
     def formfield_for_foreignkey(self, db_field, request, **kwargs):
         """Limit the queryset for foreign key fields."""
         if db_field.name in self.foreign_key_fields:

--- a/management/admin.py
+++ b/management/admin.py
@@ -14,8 +14,10 @@ class PermissionsBaseAdmin(GuardedModelAdmin):
     foreign_key_fields: list[str] = []
 
     def has_add_permission(self, request):
-        """Allow users in the standard group to add objects"""
-        return request.user.groups.filter(name="Standard").exists()
+        """Check if the user has the correct permission to add objects."""
+        return request.user.has_perm(
+            f"{self.opts.app_label}.add_{self.opts.model_name}"
+        )
 
     def has_change_permission(self, request, obj=None):
         """Check if the user has the correct permission to change the object."""

--- a/measurement/admin.py
+++ b/measurement/admin.py
@@ -13,8 +13,10 @@ class MeasurementBaseAdmin(GuardedModelAdmin):
     list_filter = ["station", "variable"]
 
     def has_add_permission(self, request):
-        """Allow all authenticated users to add objects."""
-        return request.user.is_authenticated
+        """Check if the user has the correct permission to add objects."""
+        return request.user.has_perm(
+            f"{self.opts.app_label}.add_{self.opts.model_name}"
+        )
 
     def has_change_permission(self, request, obj=None):
         """Check if the user has the correct permission to change the object."""

--- a/measurement/admin.py
+++ b/measurement/admin.py
@@ -4,7 +4,6 @@ from guardian.admin import GuardedModelAdmin
 from guardian.shortcuts import get_objects_for_user, get_perms
 
 from measurement.models import Measurement, Report
-from station.models import Station
 
 admin.site.site_header = "Paricia Administration - Measurements"
 
@@ -34,6 +33,12 @@ class MeasurementBaseAdmin(GuardedModelAdmin):
         if obj is not None:
             return "view_measurements" in get_perms(request.user, obj.station)
         return True
+
+    def get_queryset(self, request):
+        """Return a queryset of the objects that the user has view permissions for."""
+        qs = super().get_queryset(request)
+        stations = get_objects_for_user(request.user, "station.view_measurements")
+        return qs.filter(station__in=stations)
 
     def formfield_for_foreignkey(self, db_field, request, **kwargs):
         """Limit the list of stations available based on permssions."""

--- a/measurement/apps.py
+++ b/measurement/apps.py
@@ -18,3 +18,6 @@ from django.apps import AppConfig
 
 class MeasurementConfig(AppConfig):
     name = "measurement"
+
+    def ready(self):
+        import measurement.signals.handlers

--- a/measurement/models.py
+++ b/measurement/models.py
@@ -19,6 +19,7 @@ from django.db import models
 from django.urls import reverse
 from timescale.db.models.models import TimescaleModel
 
+from management.models import apply_add_permissions_to_standard_group
 from station.models import Station
 from variable.models import Variable
 
@@ -48,6 +49,11 @@ class MeasurementBase(TimescaleModel):
     minimum = models.DecimalField(
         "minimum", max_digits=14, decimal_places=6, null=True, blank=True
     )
+
+    @classmethod
+    def set_model_permissions(cls):
+        """Set model-level add permissions."""
+        apply_add_permissions_to_standard_group(cls)
 
     class Meta:
         abstract = True

--- a/measurement/signals/handlers.py
+++ b/measurement/signals/handlers.py
@@ -1,0 +1,14 @@
+from django.db.models.signals import post_migrate
+from django.dispatch import receiver
+
+from measurement.models import Measurement, Report
+
+
+@receiver(post_migrate)
+def set_model_permissions(sender, **kwargs):
+    """Set model-level permissions."""
+    for model in [
+        Measurement,
+        Report,
+    ]:
+        model.set_model_permissions()

--- a/sensor/signals/handlers.py
+++ b/sensor/signals/handlers.py
@@ -1,5 +1,5 @@
 from django.contrib.auth import get_user_model
-from django.db.models.signals import post_save
+from django.db.models.signals import post_migrate, post_save
 from django.dispatch import receiver
 
 from sensor.models import Sensor, SensorBrand, SensorType
@@ -10,6 +10,17 @@ User = get_user_model()
 @receiver(post_save, sender=SensorType)
 @receiver(post_save, sender=SensorBrand)
 @receiver(post_save, sender=Sensor)
-def set_permissions(sender, instance, **kwargs):
+def set_object_permissions(sender, instance, **kwargs):
     """Set object-level permissions"."""
-    instance.set_permissions()
+    instance.set_object_permissions()
+
+
+@receiver(post_migrate)
+def set_model_permissions(sender, **kwargs):
+    """Set model-level permissions."""
+    for model in [
+        SensorType,
+        SensorBrand,
+        Sensor,
+    ]:
+        model.set_model_permissions()

--- a/station/models.py
+++ b/station/models.py
@@ -295,9 +295,9 @@ class Station(PermissionsBase):
     def get_absolute_url(self):
         return reverse("station:station_detail", kwargs={"pk": self.pk})
 
-    def set_permissions(self):
+    def set_object_permissions(self):
         """Set object-level permissions."""
-        super().set_permissions()
+        super().set_object_permissions()
 
         standard_group = Group.objects.get(name="Standard")
         anonymous_user = get_anonymous_user()

--- a/station/signals/handlers.py
+++ b/station/signals/handlers.py
@@ -9,6 +9,7 @@ from station.models import (
     Ecosystem,
     Institution,
     Place,
+    PlaceBasin,
     Region,
     Station,
     StationType,
@@ -24,6 +25,7 @@ User = get_user_model()
 @receiver(post_save, sender=StationType)
 @receiver(post_save, sender=Place)
 @receiver(post_save, sender=Basin)
+@receiver(post_save, sender=PlaceBasin)
 @receiver(post_save, sender=Station)
 @receiver(post_save, sender=DeltaT)
 def set_object_permissions(sender, instance, **kwargs):
@@ -42,6 +44,7 @@ def set_model_permissions(sender, **kwargs):
         StationType,
         Place,
         Basin,
+        PlaceBasin,
         Station,
         DeltaT,
     ]:

--- a/station/signals/handlers.py
+++ b/station/signals/handlers.py
@@ -1,5 +1,5 @@
 from django.contrib.auth import get_user_model
-from django.db.models.signals import post_save
+from django.db.models.signals import post_migrate, post_save
 from django.dispatch import receiver
 
 from station.models import (
@@ -26,6 +26,23 @@ User = get_user_model()
 @receiver(post_save, sender=Basin)
 @receiver(post_save, sender=Station)
 @receiver(post_save, sender=DeltaT)
-def set_permissions(sender, instance, **kwargs):
+def set_object_permissions(sender, instance, **kwargs):
     """Set object-level permissions."""
-    instance.set_permissions()
+    instance.set_object_permissions()
+
+
+@receiver(post_migrate)
+def set_model_permissions(sender, **kwargs):
+    """Set model-level permissions."""
+    for model in [
+        Country,
+        Region,
+        Ecosystem,
+        Institution,
+        StationType,
+        Place,
+        Basin,
+        Station,
+        DeltaT,
+    ]:
+        model.set_model_permissions()

--- a/tests/permissions/test_permissions.py
+++ b/tests/permissions/test_permissions.py
@@ -39,7 +39,8 @@ class BasePermissionsTest:
         Args:
             user: User to test permission for
             perm (str): Permission to test for (e.g. "change_station")
-            obj: Object to test permission for
+            obj: Object to test permission for. If None, the permission is tested at the
+                model level.
             assert_true (bool): Whether the permission should be True or False
         """
 
@@ -60,7 +61,8 @@ class BasePermissionsTest:
 
         Args:
             perm (str): Permission to test for (e.g. "change_station")
-            obj: Object to test permission for
+            obj: Object to test permission for. If None, the permission is tested at the
+                model level.
             assert_owner (bool, optional): Whether the owner should have the permission.
             assert_other (bool, optional): Whether another user should have the
                 permission.
@@ -104,6 +106,10 @@ class BasePermissionsTest:
         """Test that all users can view internal objects."""
         if self.obj_internal:
             self.assert_perms(f"view_{self.model}", self.obj_internal, True, True, True)
+
+    def test_add_permissions(self):
+        """Test that all users except anonymous have model-level add permissions."""
+        self.assert_perms(f"add_{self.model}", None, True, True, False)
 
 
 class StationTypePermissionsTest(BasePermissionsTest, TestCase):

--- a/variable/signals/handlers.py
+++ b/variable/signals/handlers.py
@@ -1,5 +1,5 @@
 from django.contrib.auth import get_user_model
-from django.db.models.signals import post_save
+from django.db.models.signals import post_migrate, post_save
 from django.dispatch import receiver
 
 from variable.models import SensorInstallation, Unit, Variable
@@ -10,6 +10,17 @@ User = get_user_model()
 @receiver(post_save, sender=SensorInstallation)
 @receiver(post_save, sender=Unit)
 @receiver(post_save, sender=Variable)
-def set_permissions(sender, instance, **kwargs):
+def set_object_permissions(sender, instance, **kwargs):
     """Set object-level permissions"."""
-    instance.set_permissions()
+    instance.set_object_permissions()
+
+
+@receiver(post_migrate)
+def set_model_permissions(sender, **kwargs):
+    """Set model-level permissions."""
+    for model in [
+        SensorInstallation,
+        Unit,
+        Variable,
+    ]:
+        model.set_model_permissions()


### PR DESCRIPTION
This makes a number of changes to the permissions system, with the goal of fixing any problems for standard users.

- Apply the model level `add` permission to the standard user group for all models. This is achieved through a `post_migrate` signal. Previously, standard users were able to add objects due to the `has_add_permission` method in the admin class, but the models didn't appear in the admin homepage. This change fixes this and also allows the `has_add_permission` method to check the permissions directly.
- Use the `get_queryset` method in the admin class, which limits the objects that are visible based on view permissions. Without this, all objects would be visible even to standard users.
- Remove the `save_model` method from the admin class. This just checks that the user has correct permissions for the objects used by the object they're creating, but `formfield_for_foreignkey` already does the work by removing unsuitable options from the drop-downs
- Add `post_save` signal for PlaceBasin, which for some reason was missing before

I've tried to go through the admin site carefully as a standard user and I think everything is working now, although I may be missing something

Note: currently all the objects in the loaded data are private so won't appear to standard users. This is something we should change in the future

Close #229 