### PR TITLE
Restrict permissions level of objects created through admin

### DIFF
--- a/station/admin.py
+++ b/station/admin.py
@@ -89,6 +89,7 @@ class BasinAdmin(PermissionsBaseAdmin):
 class StationAdmin(PermissionsBaseAdmin):
     """Admin class for the Station model."""
 
+    limit_permissions_level = False
     list_display = [
         "station_id",
         "station_code",


### PR DESCRIPTION
This ensures that standard users can only create private objects through the admin page. Superusers can still create public objects. The reason is to ensure that all public objects are vetted and maintained by admins, and aren't irresponsibly changed or deleted

The exception is stations, which still maintain the three options (private, public and internal) for all users. Here, the permissions level is a bit different as it relates to visibility of measurements, and all registered users should be allowed to create public measurements.

 Close #202 