### PR TITLE
Callbacks to populate filters in report page

### DIFF
--- a/validated/dash_apps/finished_apps/daily_validation.py
+++ b/validated/dash_apps/finished_apps/daily_validation.py
@@ -7,10 +7,8 @@ import plotly.express as px
 import plotly.graph_objects as go
 from dash import Input, Output, State, dcc, html
 from dash_ag_grid import AgGrid
-from django.db.models import Max, Min
 from django_plotly_dash import DjangoDash
 
-from measurement.models import Measurement
 from measurement.validation import (
     generate_validation_report,
     reset_validated_days,
@@ -18,7 +16,12 @@ from measurement.validation import (
     save_validated_days,
     save_validated_entries,
 )
-from station.models import Station
+from validated.filters import (
+    populate_stations_dropdown_util,
+    populate_variable_dropdown_util,
+    set_date_range_util,
+    set_min_max_util,
+)
 from validated.plots import create_validation_plot
 from validated.tables import create_columns_daily, create_columns_detail
 from variable.models import Variable
@@ -585,28 +588,8 @@ def callbacks(
     Input("stations_list", "children"),
 )
 def populate_stations_dropdown(station_codes: list[str]) -> tuple[list[dict], str]:
-    """Populate the station dropdown with the available station codes, based on
-    permissions and data availability.
-
-    This will run once when the app is initialized.
-
-    Args:
-        station_codes (list[str]): List of station codes based on permissions
-
-    Returns:
-        tuple[list[dict], str]: Options for the station dropdown, default value
-    """
-    stations_with_measurements = Measurement.objects.values_list(
-        "station__station_code", flat=True
-    ).distinct()
-
-    station_options = [
-        {"label": station_code, "value": station_code}
-        for station_code in station_codes
-        if station_code in stations_with_measurements
-    ]
-    station_value = station_options[0]["value"] if station_options else None
-    return station_options, station_value
+    """Populate the station dropdown based on the list of station codes."""
+    return populate_stations_dropdown_util(station_codes)
 
 
 @app.callback(
@@ -614,34 +597,8 @@ def populate_stations_dropdown(station_codes: list[str]) -> tuple[list[dict], st
     Input("station_drop", "value"),
 )
 def populate_variable_dropdown(chosen_station: str) -> tuple[list[dict], str]:
-    """Update the variable dropdown based on the chosen station.
-
-    This will run whenever a new station is chosen.
-
-    Args:
-        chosen_station (str): Code for the chosen station
-
-    Returns:
-        tuple[list[dict], str]: Options for the variable dropdown, default value
-    """
-
-    # Filter measurements based on the chosen station
-    variable_dicts = (
-        Measurement.objects.filter(station__station_code=chosen_station)
-        .values("variable__name", "variable__variable_code")
-        .distinct()
-    )
-
-    # Create a list of dictionaries for the dropdown
-    variable_options = [
-        {
-            "label": variable["variable__name"],
-            "value": variable["variable__variable_code"],
-        }
-        for variable in variable_dicts
-    ]
-    variable_value = variable_options[0]["value"] if variable_options else None
-    return variable_options, variable_value
+    """Populate the variable dropdown based on the chosen station."""
+    return populate_variable_dropdown_util(chosen_station)
 
 
 @app.callback(
@@ -660,41 +617,10 @@ def set_date_range_min_max(
     chosen_station, chosen_variable
 ) -> tuple[str, str, Decimal, Decimal,]:
     """Set the default date range and min/max based on the chosen station and
-    variable.
-
-    This will run whenever a new station and/or variable is chosen.
-
-    Args:
-        chosen_station (str): Code for the chosen station
-        chosen_variable (str): Code for the chosen variable
-
-    Returns:
-        tuple[str, str, Decimal, Decimal]: Start date, end date, min value, max value
-    """
-    filter_vals = Measurement.objects.filter(
-        station__station_code=chosen_station,
-        variable__variable_code=chosen_variable,
-    ).aggregate(
-        first_date=Min("time"),
-        last_date=Max("time"),
-        min_value=Min("minimum"),
-        max_value=Max("maximum"),
-    )
-
-    first_date = (
-        filter_vals["first_date"].strftime("%Y-%m-%d")
-        if filter_vals["first_date"]
-        else None
-    )
-    last_date = (
-        filter_vals["last_date"].strftime("%Y-%m-%d")
-        if filter_vals["last_date"]
-        else None
-    )
-    min_value = filter_vals["min_value"] if filter_vals["min_value"] else None
-    max_value = filter_vals["max_value"] if filter_vals["max_value"] else None
-
-    return first_date, last_date, min_value, max_value
+    variable."""
+    start_date, end_date = set_date_range_util(chosen_station, chosen_variable)
+    min_val, max_val = set_min_max_util(chosen_station, chosen_variable)
+    return start_date, end_date, min_val, max_val
 
 
 @app.callback(

--- a/validated/dash_apps/finished_apps/daily_validation.py
+++ b/validated/dash_apps/finished_apps/daily_validation.py
@@ -17,10 +17,10 @@ from measurement.validation import (
     save_validated_entries,
 )
 from validated.filters import (
-    populate_stations_dropdown_util,
-    populate_variable_dropdown_util,
-    set_date_range_util,
-    set_min_max_util,
+    get_date_range,
+    get_min_max,
+    get_station_options,
+    get_variable_options,
 )
 from validated.plots import create_validation_plot
 from validated.tables import create_columns_daily, create_columns_detail
@@ -589,7 +589,7 @@ def callbacks(
 )
 def populate_stations_dropdown(station_codes: list[str]) -> tuple[list[dict], str]:
     """Populate the station dropdown based on the list of station codes."""
-    return populate_stations_dropdown_util(station_codes)
+    return get_station_options(station_codes)
 
 
 @app.callback(
@@ -598,7 +598,7 @@ def populate_stations_dropdown(station_codes: list[str]) -> tuple[list[dict], st
 )
 def populate_variable_dropdown(chosen_station: str) -> tuple[list[dict], str]:
     """Populate the variable dropdown based on the chosen station."""
-    return populate_variable_dropdown_util(chosen_station)
+    return get_variable_options(chosen_station)
 
 
 @app.callback(
@@ -618,8 +618,8 @@ def set_date_range_min_max(
 ) -> tuple[str, str, Decimal, Decimal,]:
     """Set the default date range and min/max based on the chosen station and
     variable."""
-    start_date, end_date = set_date_range_util(chosen_station, chosen_variable)
-    min_val, max_val = set_min_max_util(chosen_station, chosen_variable)
+    start_date, end_date = get_date_range(chosen_station, chosen_variable)
+    min_val, max_val = get_min_max(chosen_station, chosen_variable)
     return start_date, end_date, min_val, max_val
 
 

--- a/validated/dash_apps/finished_apps/data_report.py
+++ b/validated/dash_apps/finished_apps/data_report.py
@@ -5,11 +5,7 @@ from dash import Input, Output, State, dcc, html
 from django_plotly_dash import DjangoDash
 
 from measurement.reporting import get_report_data_from_db
-from validated.filters import (
-    populate_stations_dropdown_util,
-    populate_variable_dropdown_util,
-    set_date_range_util,
-)
+from validated.filters import get_date_range, get_station_options, get_variable_options
 from variable.models import Variable
 
 # Create a Dash app
@@ -235,7 +231,7 @@ def update_alert(figure):
 )
 def populate_stations_dropdown(station_codes: list[str]) -> tuple[list[dict], str]:
     """Populate the station dropdown based on the list of station codes."""
-    return populate_stations_dropdown_util(station_codes)
+    return get_station_options(station_codes)
 
 
 @app.callback(
@@ -244,7 +240,7 @@ def populate_stations_dropdown(station_codes: list[str]) -> tuple[list[dict], st
 )
 def populate_variable_dropdown(chosen_station: str) -> tuple[list[dict], str]:
     """Populate the variable dropdown based on the chosen station."""
-    return populate_variable_dropdown_util(chosen_station)
+    return get_variable_options(chosen_station)
 
 
 @app.callback(
@@ -261,4 +257,4 @@ def set_date_range(
     chosen_station, chosen_variable
 ) -> tuple[str, str,]:
     """Set the default date range based on the chosen station and variable."""
-    return set_date_range_util(chosen_station, chosen_variable)
+    return get_date_range(chosen_station, chosen_variable)

--- a/validated/filters.py
+++ b/validated/filters.py
@@ -1,7 +1,10 @@
+from decimal import Decimal
+from typing import Dict, List, Tuple
+
+from django.db.models import Max, Min
 from django_filters import rest_framework as filters
 
-# from validated.models import DischargeCurve
-from station.models import Station
+from measurement.models import Measurement
 
 # class PolarWindFilter(filters.FilterSet):
 #     """
@@ -80,3 +83,111 @@ class ValidatedFilterDepth(ValidatedFilter):
     depth = filters.NumberFilter(field_name="depth", lookup_expr="exact")
     min_depth = filters.NumberFilter(field_name="depth", lookup_expr="gte")
     max_depth = filters.NumberFilter(field_name="depth", lookup_expr="lte")
+
+
+def populate_stations_dropdown_util(station_codes: List[str]) -> Tuple[List[Dict], str]:
+    """Populate the station dropdown with the available station codes, based on
+    permissions and data availability.
+
+    Args:
+        station_codes (list[str]): List of station codes based on permissions
+
+    Returns:
+        tuple[list[dict], str]: Options for the station dropdown, default value
+    """
+
+    stations_with_measurements = Measurement.objects.values_list(
+        "station__station_code", flat=True
+    ).distinct()
+
+    station_options = [
+        {"label": station_code, "value": station_code}
+        for station_code in station_codes
+        if station_code in stations_with_measurements
+    ]
+    station_value = station_options[0]["value"] if station_options else None
+    return station_options, station_value
+
+
+def populate_variable_dropdown_util(chosen_station: str) -> Tuple[List[Dict], str]:
+    """Update the variable dropdown based on the chosen station.
+
+    Args:
+        chosen_station (str): Code for the chosen station
+
+    Returns:
+        tuple[list[dict], str]: Options for the variable dropdown, default value
+    """
+    variable_dicts = (
+        Measurement.objects.filter(station__station_code=chosen_station)
+        .values("variable__name", "variable__variable_code")
+        .distinct()
+    )
+
+    variable_options = [
+        {
+            "label": variable["variable__name"],
+            "value": variable["variable__variable_code"],
+        }
+        for variable in variable_dicts
+    ]
+    variable_value = variable_options[0]["value"] if variable_options else None
+    return variable_options, variable_value
+
+
+def set_date_range_util(chosen_station: str, chosen_variable: str) -> Tuple[str, str]:
+    """Set the default date range based on the chosen station and variable.
+
+    Args:
+        chosen_station (str): Code for the chosen station
+        chosen_variable (str): Code for the chosen variable
+
+    Returns:
+        tuple[str, str]: Start date, end date
+    """
+    filter_vals = Measurement.objects.filter(
+        station__station_code=chosen_station,
+        variable__variable_code=chosen_variable,
+    ).aggregate(
+        first_date=Min("time"),
+        last_date=Max("time"),
+    )
+
+    first_date = (
+        filter_vals["first_date"].strftime("%Y-%m-%d")
+        if filter_vals["first_date"]
+        else None
+    )
+    last_date = (
+        filter_vals["last_date"].strftime("%Y-%m-%d")
+        if filter_vals["last_date"]
+        else None
+    )
+
+    return first_date, last_date
+
+
+def set_min_max_util(
+    chosen_station, chosen_variable
+) -> tuple[Decimal, Decimal,]:
+    """Set the min and max based on the chosen station and variable.
+
+    Args:
+        chosen_station (str): Code for the chosen station
+        chosen_variable (str): Code for the chosen variable
+
+    Returns:
+        tuple[Decimal, Decimal]: Min value, max value
+    """
+    filter_vals = Measurement.objects.filter(
+        station__station_code=chosen_station,
+        variable__variable_code=chosen_variable,
+    ).aggregate(
+        min_value=Min("minimum"),
+        max_value=Max("maximum"),
+    )
+
+    min_value = filter_vals["min_value"] if filter_vals["min_value"] else None
+    max_value = filter_vals["max_value"] if filter_vals["max_value"] else None
+
+    return min_value, max_value

--- a/validated/filters.py
+++ b/validated/filters.py
@@ -85,9 +85,9 @@ class ValidatedFilterDepth(ValidatedFilter):
     max_depth = filters.NumberFilter(field_name="depth", lookup_expr="lte")
 
 
-def populate_stations_dropdown_util(station_codes: List[str]) -> Tuple[List[Dict], str]:
-    """Populate the station dropdown with the available station codes, based on
-    permissions and data availability.
+def get_station_options(station_codes: List[str]) -> Tuple[List[Dict], str]:
+    """Get valid station options and default value based on permissions and data
+    availability.
 
     Args:
         station_codes (list[str]): List of station codes based on permissions
@@ -109,17 +109,17 @@ def populate_stations_dropdown_util(station_codes: List[str]) -> Tuple[List[Dict
     return station_options, station_value
 
 
-def populate_variable_dropdown_util(chosen_station: str) -> Tuple[List[Dict], str]:
-    """Update the variable dropdown based on the chosen station.
+def get_variable_options(station: str) -> Tuple[List[Dict], str]:
+    """Get valid variable options and default value based on the chosen station.
 
     Args:
-        chosen_station (str): Code for the chosen station
+        station (str): Code for the chosen station
 
     Returns:
         tuple[list[dict], str]: Options for the variable dropdown, default value
     """
     variable_dicts = (
-        Measurement.objects.filter(station__station_code=chosen_station)
+        Measurement.objects.filter(station__station_code=station)
         .values("variable__name", "variable__variable_code")
         .distinct()
     )
@@ -135,19 +135,19 @@ def populate_variable_dropdown_util(chosen_station: str) -> Tuple[List[Dict], st
     return variable_options, variable_value
 
 
-def set_date_range_util(chosen_station: str, chosen_variable: str) -> Tuple[str, str]:
-    """Set the default date range based on the chosen station and variable.
+def get_date_range(station: str, variable: str) -> Tuple[str, str]:
+    """Get the date range covered by a chosen station and variable.
 
     Args:
-        chosen_station (str): Code for the chosen station
-        chosen_variable (str): Code for the chosen variable
+        station (str): Code for the chosen station
+        variable (str): Code for the chosen variable
 
     Returns:
         tuple[str, str]: Start date, end date
     """
     filter_vals = Measurement.objects.filter(
-        station__station_code=chosen_station,
-        variable__variable_code=chosen_variable,
+        station__station_code=station,
+        variable__variable_code=variable,
     ).aggregate(
         first_date=Min("time"),
         last_date=Max("time"),
@@ -167,21 +167,21 @@ def set_date_range_util(chosen_station: str, chosen_variable: str) -> Tuple[str,
     return first_date, last_date
 
 
-def set_min_max_util(
-    chosen_station, chosen_variable
+def get_min_max(
+    station, variable
 ) -> tuple[Decimal, Decimal,]:
-    """Set the min and max based on the chosen station and variable.
+    """Get the min and max of the data for a chosen station and variable.
 
     Args:
-        chosen_station (str): Code for the chosen station
-        chosen_variable (str): Code for the chosen variable
+        station (str): Code for the chosen station
+        variable (str): Code for the chosen variable
 
     Returns:
         tuple[Decimal, Decimal]: Min value, max value
     """
     filter_vals = Measurement.objects.filter(
-        station__station_code=chosen_station,
-        variable__variable_code=chosen_variable,
+        station__station_code=station,
+        variable__variable_code=variable,
     ).aggregate(
         min_value=Min("minimum"),
         max_value=Max("maximum"),


### PR DESCRIPTION
This repeats the process carried out in #219 #242 and #243 to automatically populate the filters in the data report app based on the data. Since there's a lot of shared code between the data report and validation apps, I have moved most of the code to `filters.py` (which currently contains a lot of other stuff that needs to be deleted) 

I have also removed the `clear_form` callback, as this was causing clashes with my other callbacks, and isn't really needed anyway