### PR TITLE
:bug: Load initial data in the right order

### DIFF
--- a/utilities/load_initial_data.py
+++ b/utilities/load_initial_data.py
@@ -29,9 +29,9 @@ data_files = [
     "station_basin",
     "station_placebasin",
     "station_institution",
+    "station_delta_t",
     "station_station",
     "measurement_airtemperature",
-    "station_delta_t",
 ]
 
 # It's initially necessary to delete all measurements to avoid foreign key constraints


### PR DESCRIPTION
`Delta_T` initial data should be loaded before `Station`, as the later contains references to the former. 