### PR TITLE
WIP: Add local timezone detection and setting

### DIFF
--- a/djangomain/middleware.py
+++ b/djangomain/middleware.py
@@ -1,0 +1,21 @@
+import zoneinfo
+
+from django.utils import timezone
+
+
+class TimezoneMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        try:
+            # get django_timezone from cookie
+            tzname = request.COOKIES.get("django_timezone")
+            if tzname:
+                timezone.activate(zoneinfo.ZoneInfo(tzname))
+            else:
+                timezone.deactivate()
+        except Exception:
+            timezone.deactivate()
+
+        return self.get_response(request)

--- a/djangomain/settings/settings.py
+++ b/djangomain/settings/settings.py
@@ -92,6 +92,7 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "django_plotly_dash.middleware.BaseMiddleware",
+    "djangomain.middleware.TimezoneMiddleware",
 ]
 
 ROOT_URLCONF = "djangomain.urls"

--- a/templates/base.html
+++ b/templates/base.html
@@ -22,6 +22,11 @@
   </head>
   <body>
     <div role="main" class="container py-3">
+      <script>
+        // Timezone settings
+        const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone; // e.g. "America/New_York"
+        document.cookie = "django_timezone=" + timezone;
+      </script>
       {% include "menu_bar.html" %}
       {% block content %}
       {% endblock content %}

--- a/templates/menu_bar.html
+++ b/templates/menu_bar.html
@@ -1,6 +1,8 @@
 {% load django_bootstrap5 %}
 {% load static %}
 {% load i18n %}
+{% load tz %}
+{% get_current_timezone as current_timezone %}
 <nav class="navbar navbar-expand-sm navbar-dark bg-primary">
   <div class="container-fluid">
     <a class="navbar-brand" rel="nofollow" href="{% url 'home' %}">Paricia</a>
@@ -124,6 +126,7 @@
     </ul>
     <!-- A separate menu for the user to log in or log out -->
     <ul class="nav navbar-nav pull-right">
+      <a class="nav-link" href="#">{{ current_timezone }}</a>
       <a class="nav-link"
          href="https://imperialcollegelondon.github.io/paricia/">Documentation</a>
       <!-- If the user is staff, we show the link to the admin -->


### PR DESCRIPTION
This PR adds the detection of the local timezone of the user via a small JS snippet and that information is used to set the timezone of Django. In theory, this means that all date time information displayed and input in forms will be done in such local timezone, while the information storage in the DB is kept consistently in UTC.

- [ ] Check that django forms actually honour this setting
- [ ] Check that dash apps also honour that setting