### PR TITLE
Fix owner not being set correctly

### DIFF
--- a/management/views.py
+++ b/management/views.py
@@ -337,8 +337,7 @@ class CustomCreateView(URLMixin, LoginRequiredMixin, CreateView):
         Returns:
             HttpResponse: Redirect to the detail view of the created object.
         """
-        if hasattr(form.instance, "owner"):
-            form.instance.owner = self.request.user
+        form.instance.owner = self.request.user
         return super().form_valid(form)
 
     @property


### PR DESCRIPTION
For some reason, conditionally setting the owner was not working correctly - at least not for the `data_import` model, even though the model has an `owner` field. This way we are forcing the ownership unconditionally. As all models using these forms have owner, it should work.