### PR TITLE
Reset validation if reporting fails

### DIFF
--- a/measurement/validation.py
+++ b/measurement/validation.py
@@ -252,7 +252,12 @@ def save_validated_entries(data: pd.DataFrame) -> None:
     start_time = min(times).astimezone(tz).strftime("%Y-%m-%d")
     end_time = max(times).astimezone(tz).strftime("%Y-%m-%d")
 
-    reporting.launch_reports_calculation(station, variable, start_time, end_time)
+    try:
+        reporting.launch_reports_calculation(station, variable, start_time, end_time)
+    except Exception as e:
+        ids = data[data["validate?"]]["id"].tolist()
+        reset_validated_entries(ids)
+        raise e
 
 
 def reset_validated_entries(ids: list) -> None:
@@ -305,7 +310,11 @@ def save_validated_days(data: pd.DataFrame) -> None:
     start_time = validate["date"].min()
     end_time = validate["date"].max()
 
-    reporting.launch_reports_calculation(station, variable, start_time, end_time)
+    try:
+        reporting.launch_reports_calculation(station, variable, start_time, end_time)
+    except Exception as e:
+        reset_validated_days(station, variable, start_time, end_time)
+        raise e
 
 
 def reset_validated_days(

--- a/tests/measurement/test_validation.py
+++ b/tests/measurement/test_validation.py
@@ -379,6 +379,84 @@ class TestValidationFunctions(TestCase):
         self.assertNotEqual(updated_measurement_3.maximum, measurement_3.maximum)
         self.assertNotEqual(updated_measurement_3.minimum, measurement_3.minimum)
 
+    def test_save_validated_data_error(self):
+        from django.utils import timezone
+
+        from measurement.models import Measurement
+        from measurement.validation import save_validated_entries
+
+        # Create sample data
+        data = pd.DataFrame(
+            {
+                "id": [1, 2, 3],
+                "value": [10.0, 20.0, 30.0],
+                "maximum": [15.0, 25.0, 35.0],
+                "minimum": [5.0, 15.0, 25.0],
+                "validate?": [True, False, True],
+                "deactivate?": [False, True, True],
+            }
+        )
+        data["station"] = self.station.station_code
+        data["variable"] = self.variable.variable_code
+
+        # Create some times
+        tz = timezone.get_default_timezone()
+        times = [datetime(2023, 1, i).replace(tzinfo=tz) for i in range(1, 4)]
+
+        # Create sample Measurement objects
+        measurement_1 = Measurement(
+            id=1,
+            time=times[0],
+            station=self.station,
+            variable=self.variable,
+            value=5.0,
+            maximum=10.0,
+            minimum=0.0,
+        )
+        measurement_2 = Measurement(
+            id=2,
+            time=times[1],
+            station=self.station,
+            variable=self.variable,
+            value=15.0,
+            maximum=20.0,
+            minimum=10.0,
+        )
+        measurement_3 = Measurement(
+            id=3,
+            time=times[2],
+            station=self.station,
+            variable=self.variable,
+            value=25.0,
+            maximum=30.0,
+            minimum=20.0,
+        )
+
+        # Save the sample Measurement objects
+        measurement_1.save()
+        measurement_2.save()
+        measurement_3.save()
+
+        def raise_exception(*args):
+            raise Exception("launch_reports_calculation was called")
+
+        reset_validated_entries_mock = self.create_patch(
+            "measurement.validation.reset_validated_entries"
+        )
+
+        # Call the function under test
+
+        with patch(
+            "measurement.reporting.launch_reports_calculation",
+            side_effect=raise_exception,
+        ):
+            self.assertRaises(Exception, save_validated_entries, data)
+
+        # Assert the expected call to the launch_reports_calculation function
+        reset_validated_entries_mock.assert_called_once_with(
+            data[data["validate?"]]["id"].to_list()
+        )
+
     def test_save_validated_days(self):
         from measurement.models import Measurement
         from measurement.validation import save_validated_days


### PR DESCRIPTION
The report calculation needs the data to be validated, so what it is done is that if anything fails during the report calculation, the validation is reset. This is done for both the full day validation and the individual entries validation.

Close #383 