### PR TITLE
Allow to reformat days without rounding to full months

### DIFF
--- a/measurement/dash_apps/data_report.py
+++ b/measurement/dash_apps/data_report.py
@@ -140,6 +140,7 @@ def update_graph(
         start_time=start_time,
         end_time=end_time,
         report_type=temporality,
+        whole_months=False,
     )
     if data.empty:
         return create_empty_plot()
@@ -202,6 +203,7 @@ def download_csv_report(
                     start_time=start_time,
                     end_time=end_time,
                     report_type=temporality,
+                    whole_months=False,
                 )
                 .drop(columns=["station", "variable", "data_import_id"])
                 .dropna(axis=1, how="all")

--- a/tests/measurement/test_reporting.py
+++ b/tests/measurement/test_reporting.py
@@ -71,8 +71,8 @@ class TestReporting(TestCase):
 
         # Define test parameters
         tz = timezone.get_current_timezone()
-        start_time = "2023-01-01"
-        end_time = "2023-12-31"
+        start_time = "2023-01-06"
+        end_time = "2023-12-15"
 
         # Call the function under test
         result = reformat_dates(start_time, end_time)
@@ -80,6 +80,25 @@ class TestReporting(TestCase):
         # Assert the start and end dates
         expected_start_time = datetime(2023, 1, 1, tzinfo=tz)
         expected_end_time = datetime(2023, 12, 31, 23, 59, 59, tzinfo=tz)
+        self.assertEqual(result[0], expected_start_time)
+        self.assertEqual(result[1], expected_end_time)
+
+    def test_reformat_dates_partial_months(self):
+        from django.utils import timezone
+
+        from measurement.reporting import reformat_dates
+
+        # Define test parameters
+        tz = timezone.get_current_timezone()
+        start_time = "2023-01-06"
+        end_time = "2023-12-15"
+
+        # Call the function under test
+        result = reformat_dates(start_time, end_time, whole_months=False)
+
+        # Assert the start and end dates
+        expected_start_time = datetime(2023, 1, 6, tzinfo=tz)
+        expected_end_time = datetime(2023, 12, 15, 23, 59, 59, tzinfo=tz)
         self.assertEqual(result[0], expected_start_time)
         self.assertEqual(result[1], expected_end_time)
 


### PR DESCRIPTION
This is useful to select exactly what you want to retrieve from the database to plot and download, which will speedup things for the user.

Close #401 