### PR TITLE
Add inline classifications to format

### DIFF
--- a/management/views.py
+++ b/management/views.py
@@ -103,6 +103,22 @@ class CustomDetailView(URLMixin, LoginRequiredMixin, DetailView):
             raise PermissionDenied
         return obj
 
+    def get_inline(self) -> dict | None:
+        """Return the inline data for the format.
+
+        If provided, this method should return a dictionary with the inline data to be
+        shown in the detail view. The dictionary should have the following keys:
+
+        - title: Title of the inline data.
+        - header: List with the header of the table.
+        - objects: List with the objects to be shown in the table. Each object should be
+            a list with the same length as the header.
+
+        Returns:
+            dict | None: Inline data for the format.
+        """
+        return None
+
     def get_form(self):
         class DetailForm(forms.ModelForm):
             class Meta:
@@ -120,6 +136,7 @@ class CustomDetailView(URLMixin, LoginRequiredMixin, DetailView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["form"] = self.get_form()
+        context["inline"] = self.get_inline()
         context["title"] = self.model_description
         context["delete_url"] = self.delete_url
         context["edit_url"] = self.edit_url

--- a/templates/object_detail.html
+++ b/templates/object_detail.html
@@ -22,4 +22,22 @@
       {% bootstrap_form form layout='horizontal' %}
     </div>
   </div>
+  <!-- Inline details, if any -->
+  {% if inline %}
+    <h3>{{ inline.title }}</h3>
+    <table class="table">
+      <thead class="thead-light">
+        <tr>
+          {% for field in inline.header %}<th scope="col">{{ field }}</th>{% endfor %}
+        </tr>
+      </thead>
+      <tbody>
+        {% for obj in inline.objects %}
+          <tr>
+            {% for value in obj %}<td>{{ value }}</td>{% endfor %}
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  {% endif %}
 {% endblock content %}


### PR DESCRIPTION
Add the classifications (i.e. the variables and the column they can be found) to the format detail view. Links are included to the classification object, the variable and the unit, so they can be explored further. 

<img width="781" alt="image" src="https://github.com/user-attachments/assets/d723b464-eb2a-4447-ab42-d4db3b5c8d75">

Things have been setup in a general form, such that they can be added to any detail view, should that be needed. 

Close #407 