### PR TITLE
Add plot resampling to validation app

### DIFF
--- a/djangomain/settings/settings.py
+++ b/djangomain/settings/settings.py
@@ -346,3 +346,5 @@ TB_CUSTOMER_DEVICES_URL = (
 TB_TIMESERIES_URL = (
     f"https://{TB_HOST}/api/plugins/telemetry/DEVICE/{{tb_device_id}}/values/timeseries"
 )
+
+MAX_POINTS = 1000  # Max points to display in plots

--- a/measurement/dash_apps/daily_validation.py
+++ b/measurement/dash_apps/daily_validation.py
@@ -6,10 +6,10 @@ import dash_bootstrap_components as dbc
 import pandas as pd
 from dash import Input, Output, State, dcc, html
 from dash_ag_grid import AgGrid
+from django.conf import settings
 from django_plotly_dash import DjangoDash
 from plotly import graph_objs as go
 
-from djangomain.settings.settings import MAX_POINTS
 from variable.models import Variable
 
 from ..filters import (
@@ -596,7 +596,7 @@ def callbacks(
                 plot_data = plot_data[
                     (plot_data["time"] >= start) & (plot_data["time"] <= end)
                 ]
-            every = max(1, len(plot_data) // MAX_POINTS)
+            every = max(1, len(plot_data) // settings.MAX_POINTS)
             plot_data = plot_data.iloc[::every]
             out_plot = create_validation_plot(
                 data=plot_data,

--- a/measurement/dash_apps/daily_validation.py
+++ b/measurement/dash_apps/daily_validation.py
@@ -36,6 +36,7 @@ app = DjangoDash(
 SELECTED_DAY: date | None = None
 DATA_SUMMARY: pd.DataFrame = pd.DataFrame()
 DATA_GRANULAR: pd.DataFrame = pd.DataFrame()
+MAX_POINTS = 1000
 
 # Filters
 filters_row1 = html.Div(
@@ -337,6 +338,7 @@ app.layout = html.Div(
         Input("save-button", "n_clicks"),
         Input("detail-date-picker", "date"),
         Input("plot_radio", "value"),
+        Input("plot", "relayoutData"),
     ],
     [
         State("tabs", "value"),
@@ -351,6 +353,7 @@ app.layout = html.Div(
         State("table_detail", "selectedRows"),
         State("table_detail", "rowData"),
         State("validation_status_drop", "value"),
+        State("plot", "figure"),
     ],
     prevent_initial_call=True,
 )
@@ -359,6 +362,7 @@ def callbacks(
     in_save_clicks: int,
     in_detail_date: str,
     in_plot_radio_value: str,
+    in_plot_relayout_data: dict,
     in_tabs_value: str,
     in_station: str,
     in_variable: str,
@@ -371,6 +375,7 @@ def callbacks(
     in_detail_selected_rows: list[dict],
     in_detail_row_data: list[dict],
     in_validation_status: str,
+    in_plot_figure: go.Figure,
 ) -> tuple[
     dash.no_update,
     dash.no_update,
@@ -392,6 +397,7 @@ def callbacks(
         in_save_clicks (int): Number of times save-button was clicked
         in_detail_date (str): Date for detail view
         in_plot_radio_value (str): Value of plot radio button
+        in_plot_relayout_data (dict): Plot relayout data
         in_tabs_value (str): Value of tabs
         in_station (str): Station from filters
         in_variable (str): Variable from filters
@@ -403,6 +409,7 @@ def callbacks(
         in_daily_row_data (list[dict]): Full row data for table_daily
         in_detail_selected_rows (list[dict]): Selected rows in table_detail
         in_detail_row_data (list[dict]): Full row data for table_detail
+        in_plot_figure (go.Figure): Plot
 
     Returns:
         out_loading_top (dash.no_update): Loading spinner for top
@@ -565,6 +572,10 @@ def callbacks(
     elif input_id == "plot_radio":
         plot_refresh_required = True
 
+    # Plot
+    elif input_id == "plot":
+        plot_refresh_required = True
+
     # Reload data
     if data_refresh_required:
         DATA_SUMMARY, DATA_GRANULAR = generate_validation_report(
@@ -580,8 +591,17 @@ def callbacks(
     # Refresh plot
     if plot_refresh_required:
         if not DATA_GRANULAR.empty:
+            plot_data = DATA_GRANULAR.copy()
+            if "xaxis.range[0]" in in_plot_relayout_data:
+                start = in_plot_relayout_data["xaxis.range[0]"]
+                end = in_plot_relayout_data["xaxis.range[1]"]
+                plot_data = plot_data[
+                    (plot_data["time"] >= start) & (plot_data["time"] <= end)
+                ]
+            every = max(1, len(plot_data) // MAX_POINTS)
+            plot_data = plot_data.iloc[::every]
             out_plot = create_validation_plot(
-                data=DATA_GRANULAR,
+                data=plot_data,
                 variable_name=Variable.objects.get(variable_code=in_variable).name,
                 field=in_plot_radio_value,
             )

--- a/measurement/dash_apps/daily_validation.py
+++ b/measurement/dash_apps/daily_validation.py
@@ -9,6 +9,7 @@ from dash_ag_grid import AgGrid
 from django_plotly_dash import DjangoDash
 from plotly import graph_objs as go
 
+from djangomain.settings.settings import MAX_POINTS
 from variable.models import Variable
 
 from ..filters import (
@@ -36,7 +37,7 @@ app = DjangoDash(
 SELECTED_DAY: date | None = None
 DATA_SUMMARY: pd.DataFrame = pd.DataFrame()
 DATA_GRANULAR: pd.DataFrame = pd.DataFrame()
-MAX_POINTS = 1000
+
 
 # Filters
 filters_row1 = html.Div(
@@ -588,7 +589,7 @@ def callbacks(
     # Refresh plot
     if plot_refresh_required:
         if not DATA_GRANULAR.empty:
-            plot_data = DATA_GRANULAR.copy()
+            plot_data = DATA_GRANULAR
             if "xaxis.range[0]" in in_plot_relayout_data:
                 start = in_plot_relayout_data["xaxis.range[0]"]
                 end = in_plot_relayout_data["xaxis.range[1]"]

--- a/measurement/dash_apps/daily_validation.py
+++ b/measurement/dash_apps/daily_validation.py
@@ -353,7 +353,6 @@ app.layout = html.Div(
         State("table_detail", "selectedRows"),
         State("table_detail", "rowData"),
         State("validation_status_drop", "value"),
-        State("plot", "figure"),
     ],
     prevent_initial_call=True,
 )
@@ -375,7 +374,6 @@ def callbacks(
     in_detail_selected_rows: list[dict],
     in_detail_row_data: list[dict],
     in_validation_status: str,
-    in_plot_figure: go.Figure,
 ) -> tuple[
     dash.no_update,
     dash.no_update,
@@ -409,7 +407,6 @@ def callbacks(
         in_daily_row_data (list[dict]): Full row data for table_daily
         in_detail_selected_rows (list[dict]): Selected rows in table_detail
         in_detail_row_data (list[dict]): Full row data for table_detail
-        in_plot_figure (go.Figure): Plot
 
     Returns:
         out_loading_top (dash.no_update): Loading spinner for top

--- a/measurement/dash_apps/data_report.py
+++ b/measurement/dash_apps/data_report.py
@@ -3,9 +3,9 @@ from logging import getLogger
 import dash_bootstrap_components as dbc
 import plotly.graph_objs as go
 from dash import Input, Output, State, dcc, html
+from django.conf import settings
 from django_plotly_dash import DjangoDash
 
-from djangomain.settings.settings import MAX_POINTS
 from variable.models import Variable
 
 from ..filters import get_date_range, get_station_options, get_variable_options
@@ -156,7 +156,7 @@ def update_graph(
         data = data[(data["time"] >= start) & (data["time"] <= end)]
 
     try:
-        every = max(1, len(data) // MAX_POINTS)
+        every = max(1, len(data) // settings.MAX_POINTS)
         resampled = data.iloc[::every]
         agg = get_aggregation_level(resampled["time"], every > 1)
         resampled = add_nans_for_gaps(resampled)

--- a/measurement/dash_apps/data_report.py
+++ b/measurement/dash_apps/data_report.py
@@ -5,6 +5,7 @@ import plotly.graph_objs as go
 from dash import Input, Output, State, dcc, html
 from django_plotly_dash import DjangoDash
 
+from djangomain.settings.settings import MAX_POINTS
 from variable.models import Variable
 
 from ..filters import get_date_range, get_station_options, get_variable_options
@@ -16,7 +17,6 @@ from .plots import (
     get_aggregation_level,
 )
 
-MAX_POINTS = 1000
 """Maximum number of points to display in the graph."""
 
 # Create a Dash app

--- a/measurement/validation.py
+++ b/measurement/validation.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from decimal import Decimal
+from functools import lru_cache
 
 import pandas as pd
 from django.utils import timezone
@@ -210,6 +211,7 @@ def generate_daily_summary(
     return report
 
 
+@lru_cache(1)
 def generate_validation_report(
     station: str,
     variable: str,


### PR DESCRIPTION
This PR adds plot resampling to the validation app, similar to what is already implemented for the reporting app.

- I have followed the general implementation in the reporting app
- `plot_refresh_required` is additionally set to `True` if the plot is updated
  - `MAX_POINTS` is used to sample `plot_data`, also set to 1000 here 
- `lru_cache` is added to `generate_validation_report` to cache results

Closes #399 