### PR TITLE
Hide edit and delete buttons for non-owner

### DIFF
--- a/management/views.py
+++ b/management/views.py
@@ -270,7 +270,9 @@ class CustomDetailView(URLMixin, LoginRequiredMixin, DetailView):
         context["edit_url"] = self.edit_url
         context["list_url"] = self.list_url
         context["pk"] = self.object.pk
-        context["can_edit"] = self.request.user == self.object.owner
+        context["can_edit"] = (
+            self.request.user == self.object.owner or self.request.user.is_superuser
+        )
         return context
 
     @property

--- a/management/views.py
+++ b/management/views.py
@@ -270,6 +270,7 @@ class CustomDetailView(URLMixin, LoginRequiredMixin, DetailView):
         context["edit_url"] = self.edit_url
         context["list_url"] = self.list_url
         context["pk"] = self.object.pk
+        context["can_edit"] = self.request.user == self.object.owner
         return context
 
     @property

--- a/templates/object_detail.html
+++ b/templates/object_detail.html
@@ -11,8 +11,10 @@
   <div class="row">
     <div class="col">
       <a href="{% url list_url %}" class="btn btn-success">Return to list</a>
-      <a href="{% url edit_url pk %}" class="btn btn-warning">Edit</a>
-      <a href="{% url delete_url pk %}" class="btn btn-danger">Delete</a>
+      {% if can_edit or user.is_superuser %}
+        <a href="{% url edit_url pk %}" class="btn btn-warning">Edit</a>
+        <a href="{% url delete_url pk %}" class="btn btn-danger">Delete</a>
+      {% endif %}
     </div>
   </div>
   <!-- Object details -->

--- a/templates/object_detail.html
+++ b/templates/object_detail.html
@@ -11,7 +11,7 @@
   <div class="row">
     <div class="col">
       <a href="{% url list_url %}" class="btn btn-success">Return to list</a>
-      {% if can_edit or user.is_superuser %}
+      {% if can_edit %}
         <a href="{% url edit_url pk %}" class="btn btn-warning">Edit</a>
         <a href="{% url delete_url pk %}" class="btn btn-danger">Delete</a>
       {% endif %}

--- a/tests/management/test_views.py
+++ b/tests/management/test_views.py
@@ -142,6 +142,9 @@ class TestCustomDetailView(TestCase):
         from management.views import CustomDetailView
         from sensor.models import Sensor
 
+        self.sensor.owner = self.user
+        self.sensor.save()
+
         request = self.factory.get("/fake-url")
         request.user = self.user
         view = CustomDetailView()
@@ -155,6 +158,7 @@ class TestCustomDetailView(TestCase):
         self.assertIsNone(context["delete_url"])
         self.assertIsNone(context["edit_url"])
         self.assertIsNone(context["list_url"])
+        self.assertTrue(context["can_edit"])
 
     def test_properties(self):
         from management.views import CustomDetailView

--- a/tests/management/test_views.py
+++ b/tests/management/test_views.py
@@ -160,6 +160,23 @@ class TestCustomDetailView(TestCase):
         self.assertIsNone(context["list_url"])
         self.assertTrue(context["can_edit"])
 
+    def test_get_context_data_can_edit_false(self):
+        from management.views import CustomDetailView
+        from sensor.models import Sensor
+
+        self.sensor.owner = None
+        self.sensor.save()
+
+        request = self.factory.get("/fake-url")
+        request.user = self.user
+        view = CustomDetailView()
+        view.request = request
+        view.kwargs = {"pk": self.sensor.pk}
+        view.model = Sensor
+        view.object = view.get_object()
+        context = view.get_context_data()
+        self.assertFalse(context["can_edit"])
+
     def test_properties(self):
         from management.views import CustomDetailView
         from sensor.models import Sensor


### PR DESCRIPTION
This PR hides the edit and delete buttons in the object detail views if the user is not the owner or admin.

Closes #446 