### PR TITLE
Implement reprocess as a RadioSelect button

### DIFF
--- a/importing/views.py
+++ b/importing/views.py
@@ -52,16 +52,6 @@ class DataImportDetailView(CustomDetailView):
 
     model = DataImport
 
-    def get_form(self):
-        """Exclude the reprocess field from the form."""
-
-        class DetailForm(forms.ModelForm):
-            class Meta:
-                model = self.model
-                exclude = ["reprocess"]
-
-        return DetailForm(instance=self.object)
-
 
 class DataImportListView(CustomTableView):
     """View to list all data imports."""

--- a/importing/views.py
+++ b/importing/views.py
@@ -52,6 +52,16 @@ class DataImportDetailView(CustomDetailView):
 
     model = DataImport
 
+    def get_form(self):
+        """Exclude the reprocess field from the form."""
+
+        class DetailForm(forms.ModelForm):
+            class Meta:
+                model = self.model
+                exclude = ["reprocess"]
+
+        return DetailForm(instance=self.object)
+
 
 class DataImportListView(CustomTableView):
     """View to list all data imports."""
@@ -68,6 +78,15 @@ class DataImportEditView(CustomEditView):
     model = DataImport
     fields = ["visibility", "station", "format", "rawfile", "reprocess", "observations"]
     foreign_key_fields = ["station", "format"]
+
+    def get_form(self, form_class=None):
+        """Implement the reprocess option as a RadioSelect button."""
+        form = super().get_form(form_class)
+        form.fields["reprocess"].widget = forms.RadioSelect(
+            choices=((True, "Yes"), (False, "No"))
+        )
+        form.fields["reprocess"].help_text = "If 'Yes', the data will be reprocessed."
+        return form
 
 
 class DataImportCreateView(CustomCreateView):

--- a/importing/views.py
+++ b/importing/views.py
@@ -1,6 +1,7 @@
 import json
 import logging
 
+from django import forms
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.core.files.base import ContentFile
@@ -75,6 +76,15 @@ class DataImportCreateView(CustomCreateView):
     model = DataImport
     fields = ["visibility", "station", "format", "rawfile", "reprocess", "observations"]
     foreign_key_fields = ["station", "format"]
+
+    def get_form(self, form_class=None):
+        """Implement the reprocess option as a RadioSelect button."""
+        form = super().get_form(form_class)
+        form.fields["reprocess"].widget = forms.RadioSelect(
+            choices=((True, "Yes"), (False, "No"))
+        )
+        form.fields["reprocess"].help_text = "If 'Yes', the data will be reprocessed."
+        return form
 
 
 class DataImportDeleteView(CustomDeleteView):


### PR DESCRIPTION
This PR updates the reprocess option in the custom data import views.

- In the create and update views, it is implemented as a `RadioSelect` button (selecting Yes or No)

<img width="360" height="72" alt="reprocess_button" src="https://github.com/user-attachments/assets/d525b0af-8375-4d1c-9ecc-88dcf49452b4" />


Closes #374 