### PR TITLE
pin mkdocs to less than 2.0 and add env to supress warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: postgres
+          DISABLE_MKDOCS_2_WARNING: true
         ports:
           - 5432:5432
         # needed because the postgres container does not provide a healthcheck

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ dev = [
 ]
 
 doc = [
-    "mkdocs",
+    "mkdocs<2.0.0",
     "mkdocstrings",
     "mkdocstrings-python>=1.11",
     "mkdocs-material",


### PR DESCRIPTION
Fixes #619 