### PR TITLE
Change dimensions of map in landing page

### DIFF
--- a/djangomain/dash_apps/stations_map.py
+++ b/djangomain/dash_apps/stations_map.py
@@ -201,7 +201,7 @@ _sidebar = dbc.Col(
 _map_col = dbc.Col(
     dcc.Graph(
         id="map_graph",
-        style={"height": "50vh"},
+        style={"height": "100vh"},
         config={"scrollZoom": True},
         figure={
             "data": [],

--- a/templates/base.html
+++ b/templates/base.html
@@ -21,7 +21,7 @@
     {% bootstrap_messages %}
   </head>
   <body>
-    <div role="main" class="container py-3">
+    <div role="main" class="container-fluid py-3">
       <script>
         // Timezone settings
         const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone; // e.g. "America/New_York"

--- a/templates/base.html
+++ b/templates/base.html
@@ -21,7 +21,7 @@
     {% bootstrap_messages %}
   </head>
   <body>
-    <div role="main" class="container-fluid py-3">
+    <div role="main" class="container py-3">
       <script>
         // Timezone settings
         const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone; // e.g. "America/New_York"

--- a/templates/home.html
+++ b/templates/home.html
@@ -3,7 +3,7 @@
 {% load static %}
 {% load plotly_dash %}
 {% block content %}
-  <div class="container-fluid py-2">
+  <div class="container py-2">
     Welcome to the <b>Paricia</b> system.
     <br />
     <br />

--- a/templates/home.html
+++ b/templates/home.html
@@ -3,7 +3,7 @@
 {% load static %}
 {% load plotly_dash %}
 {% block content %}
-  <div class="container py-2">
+  <div class="container-fluid py-2">
     Welcome to the <b>Paricia</b> system.
     <br />
     <br />

--- a/templates/home.html
+++ b/templates/home.html
@@ -17,6 +17,6 @@
     }
   </style>
   <div class="{% plotly_class name='StationsMap' %} card stations-map-card">
-    {% plotly_app name="StationsMap" initial_arguments=django_context ratio=1 %}
+    {% plotly_app name="StationsMap" initial_arguments=django_context ratio=0.5 %}
   </div>
 {% endblock content %}


### PR DESCRIPTION
This PR changes the layout of the landing page

- In the landing page, there is no longer a block of white space below the visible portion of the map
  - This is done by changing the `plotly_app` `ratio` of height to width
 
<img width="1340" height="881" alt="Screenshot 2026-06-18 at 14 07 55" src="https://github.com/user-attachments/assets/a9b5afdc-2394-4940-8611-48ca98d98c09" />


Closes #634 