### PR TITLE
Fix docs deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,5 +1,6 @@
 on:
   workflow_call:
+  workflow_dispatch:
 
 jobs:
   docs:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,33 @@
+on:
+  workflow_call:
+
+jobs:
+  docs:
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: 3.14
+          cache: pip
+          cache-dependency-path: requirements*.txt
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-doc.txt
+          pip install .
+      - name: Build docs
+        run: |
+          mkdocs build -f config/en/mkdocs.yml
+          mkdocs build -f config/es/mkdocs.yml
+      - name: Copy index redirect
+        run: cp docs/index.html site/index.html
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./site
+          publish_branch: gh-pages

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,32 +35,5 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
 
   docs:
+    uses: ./.github/workflows/docs.yml
     needs: test
-    timeout-minutes: 15
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
-        with:
-          python-version: 3.14
-          cache: pip
-          cache-dependency-path: requirements*.txt
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements-doc.txt
-          pip install .
-      - name: Build docs
-        run: |
-          mkdocs build -f config/en/mkdocs.yml
-          mkdocs build -f config/es/mkdocs.yml
-      - name: Copy index redirect
-        run: cp docs/index.html site/index.html
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./site
-          publish_branch: gh-pages

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,6 +38,8 @@ jobs:
     needs: test
     timeout-minutes: 15
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -50,5 +52,15 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements-doc.txt
           pip install .
-      - name: Deploy Docs
-        run: mkdocs gh-deploy --force
+      - name: Build docs
+        run: |
+          mkdocs build -f config/en/mkdocs.yml
+          mkdocs build -f config/es/mkdocs.yml
+      - name: Copy index redirect
+        run: cp docs/index.html site/index.html
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./site
+          publish_branch: gh-pages

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,6 +1,7 @@
-{# djlint:off #}
 <!DOCTYPE HTML>
-<html lang="en-US">
+<!-- djlint:off H030,H031 -->
+<html lang="en-GB">
+  <!-- djlint:on -->
   <head>
     <meta charset="utf-8">
     <meta http-equiv="refresh" content="0; url=/paricia/en/">
@@ -8,8 +9,8 @@
     <title>Page Redirection</title>
   </head>
   <body>
-    <!-- Note: don't tell people to `click` the link, just tell them that it is a link. -->
+    <!-- djlint:off D018 -->
     If you are not redirected automatically, follow this <a href='/paricia/en/'>link</a>.
+    <!-- djlint:on -->
   </body>
 </html>
-{# djlint:on #}

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,15 @@
+{# djlint:off #}
+<!DOCTYPE HTML>
+<html lang="en-US">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=/paricia/en/">
+    <script type="text/javascript">window.location.href = "/paricia/en/"</script>
+    <title>Page Redirection</title>
+  </head>
+  <body>
+    <!-- Note: don't tell people to `click` the link, just tell them that it is a link. -->
+    If you are not redirected automatically, follow this <a href='/paricia/en/'>link</a>.
+  </body>
+</html>
+{# djlint:on #}


### PR DESCRIPTION
This PR helps with getting the docs to deploy (I noticed the docs had not updated with the new release).

Summary:
- The current workflow to deploy the docs doesn't work because `mkdocs gh-deploy --force` doesn't work if there is no `mkdocs.yml` in the root directory.
- This PR builds the docs for each language and publishes the `site` directory to the `gh-pages` branch. 
- I've added the `index.html` that is currently being used in the `gh-pages` branch, which is copied into the `site` directory, so that the user is redirected to the EN version as default. 

Note:
- I'm not sure how to disable djlint from checking a specific fpath (rather than turning it off within the file)

Closes #639 
Closes #356 