### PR TITLE
Get db configuration from env vars for production

### DIFF
--- a/djangomain/settings/production.py
+++ b/djangomain/settings/production.py
@@ -8,5 +8,12 @@ SECURE_BROWSER_XSS_FILTER = True
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 SECURE_HSTS_SECONDS = 15552000
 SECRET_KEY = os.environ["SECRET_KEY"]
-DATABASES["default"]["PASSWORD"] = os.environ["POSTGRES_PASSWORD"]  # noqa: F405
+DATABASES["default"] = {  # noqa: F405
+    "ENGINE": "django.db.backends.postgresql",
+    "NAME": os.environ["POSTGRES_DB"],
+    "USER": os.environ["POSTGRES_USER"],
+    "PASSWORD": os.environ["POSTGRES_PASSWORD"],
+    "HOST": os.environ["POSTGRES_HOST"],
+    "PORT": os.environ.get("POSTGRES_PORT", "5432"),
+}
 MIDDLEWARE.insert(1, "whitenoise.middleware.WhiteNoiseMiddleware")  # noqa: F405


### PR DESCRIPTION
As we are migrating to an Azure App service + a PostgreSQL database, this PR updates the production settings so that the database connection is configured all from environment variables (currently only the password is configured this way)