### PR TITLE
Enable publish workflow to be run manually

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,7 @@
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 jobs:
   test:
@@ -33,6 +34,7 @@ jobs:
           context: .
           push: true
           tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
 
   docs:
     uses: ./.github/workflows/docs.yml

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,6 +27,12 @@ jobs:
         uses: docker/metadata-action@v6
         with:
           images: ghcr.io/${{ github.repository }}
+          flavor: |
+            latest=auto
+          tags: |
+            type=ref,event=tag
+            type=ref,event=branch
+            type=raw,value=latest,enable=${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' }}
 
       - name: Build and push Docker image for the web app
         uses: docker/build-push-action@v7


### PR DESCRIPTION
This adds `workflow_dispatch` to the publish workflow so that it can be run manually (useful for Azure deployment). 

I've also added the labels to the metadata so we can see more info, e.g. which commit it was generated from. 

I believe, according to the [metadata-action readme](https://github.com/docker/metadata-action), that the tag for a manually triggered workflow will use the branch name, i.e. `:main`, rather than `:latest`. But `:latest` and the version tags, i.e. `:v1.2.0` will still point to the published releases. Is this ok?

Closes #647 

