### PR TITLE
Move whitenoise middleware

### DIFF
--- a/djangomain/settings/settings.py
+++ b/djangomain/settings/settings.py
@@ -86,6 +86,7 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
+    "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
@@ -94,7 +95,6 @@ MIDDLEWARE = [
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "django_plotly_dash.middleware.BaseMiddleware",
     "djangomain.middleware.TimezoneMiddleware",
-    "whitenoise.middleware.WhiteNoiseMiddleware",
 ]
 
 ROOT_URLCONF = "djangomain.urls"


### PR DESCRIPTION
This PR moves Whitenoise Middleware to directly after Django Security Middleware.

Q: I have left the caddyfile for now (even though the plan is to use Azure App service where it is not relevant) -- OK?

Closes #651 